### PR TITLE
ドメインモデルの実装を変更 #61

### DIFF
--- a/src/main/kotlin/com/assari/voicebooklm/domain/model/Formatting.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/domain/model/Formatting.kt
@@ -17,6 +17,17 @@ data class Formatting(
     /** フォールバックが使用されたかどうか */
     val fallbackUsed: Boolean = false,
 ) {
+    init {
+        validate()
+    }
+
+    private fun validate() {
+        if (status == FormattingStatus.COMPLETED) {
+            require(!title.isNullOrBlank()) { "title must not be blank when status is COMPLETED" }
+            require(!content.isNullOrBlank()) { "content must not be blank when status is COMPLETED" }
+        }
+    }
+
     /**
      * AI整形が完了しているかどうか
      */

--- a/src/main/kotlin/com/assari/voicebooklm/domain/model/RefreshToken.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/domain/model/RefreshToken.kt
@@ -5,11 +5,6 @@ import java.util.UUID
 
 /**
  * リフレッシュトークンドメインモデル
- *
- * JWT リフレッシュトークンの情報を表現する純粋な Kotlin クラス。
- * トークンローテーション（使用後に無効化して新しいトークンを発行）をサポート。
- * フレームワーク依存なし（Domain Layer）。
- * イミュータブルな設計で、変更時は新しいインスタンスを返す。
  */
 data class RefreshToken(
     val id: UUID,

--- a/src/main/kotlin/com/assari/voicebooklm/domain/model/RefreshToken.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/domain/model/RefreshToken.kt
@@ -9,14 +9,15 @@ import java.util.UUID
  * JWT リフレッシュトークンの情報を表現する純粋な Kotlin クラス。
  * トークンローテーション（使用後に無効化して新しいトークンを発行）をサポート。
  * フレームワーク依存なし（Domain Layer）。
+ * イミュータブルな設計で、変更時は新しいインスタンスを返す。
  */
-class RefreshToken(
+data class RefreshToken(
     val id: UUID,
     val token: String,
     val userId: UUID,
     val expiresAt: Instant,
     val createdAt: Instant = Instant.now(),
-    var revoked: Boolean = false
+    val revoked: Boolean = false,
 ) {
     /**
      * トークンが有効期限切れかどうかを判定する
@@ -34,11 +35,9 @@ class RefreshToken(
     }
 
     /**
-     * トークンを無効化する
+     * トークンを無効化した新しいインスタンスを返す
      */
-    fun revoke() {
-        this.revoked = true
-    }
+    fun revoke(): RefreshToken = if (revoked) this else copy(revoked = true)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/com/assari/voicebooklm/domain/model/Transcription.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/domain/model/Transcription.kt
@@ -15,6 +15,17 @@ data class Transcription(
     /** フォールバックが使用されたかどうか */
     val fallbackUsed: Boolean = false,
 ) {
+    init {
+        validate()
+    }
+
+    private fun validate() {
+        require(languageCode.isNotBlank()) { "languageCode must not be blank" }
+        if (status == TranscriptionStatus.COMPLETED) {
+            require(!text.isNullOrBlank()) { "text must not be blank when status is COMPLETED" }
+        }
+    }
+
     /**
      * 文字起こしが完了しているかどうか
      */

--- a/src/main/kotlin/com/assari/voicebooklm/domain/model/User.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/domain/model/User.kt
@@ -26,8 +26,6 @@ data class User(
         updatedAt = Instant.now()
     )
 
-    // data class のデフォルト equals/hashCode はすべてのプロパティを比較するが、
-    // エンティティとしての等価性は id のみで判断する
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is User) return false

--- a/src/main/kotlin/com/assari/voicebooklm/domain/model/VoiceMemo.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/domain/model/VoiceMemo.kt
@@ -203,9 +203,9 @@ data class VoiceMemo(
          * 新しい VoiceMemo を作成する（処理待ち状態）
          */
         fun create(
+            id: UUID,
             userId: UUID,
             languageCode: String = "ja-JP",
-            id: UUID = UUID.randomUUID(),
         ): VoiceMemo = VoiceMemo(
             id = id,
             userId = userId,

--- a/src/main/kotlin/com/assari/voicebooklm/domain/model/VoiceMemo.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/domain/model/VoiceMemo.kt
@@ -237,4 +237,12 @@ data class VoiceMemo(
             updatedAt = updatedAt,
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is VoiceMemo) return false
+        return id == other.id
+    }
+
+    override fun hashCode(): Int = id.hashCode()
 }

--- a/src/main/kotlin/com/assari/voicebooklm/infrastructure/api/storage/GcsStorageService.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/infrastructure/api/storage/GcsStorageService.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
+import com.github.f4b6a3.uuid.UuidCreator
 import java.util.UUID
 
 /**
@@ -44,7 +45,7 @@ class GcsStorageService(
         mimeType: String,
     ): GcsUploadResult = withContext(Dispatchers.IO) {
         val extension = mimeTypeToExtension(mimeType)
-        val objectName = "$AUDIO_PREFIX$userId/${UUID.randomUUID()}$extension"
+        val objectName = "$AUDIO_PREFIX$userId/${UuidCreator.getTimeOrderedEpoch()}$extension"
 
         val blobId = BlobId.of(bucketName, objectName)
         val blobInfo = BlobInfo.newBuilder(blobId)

--- a/src/main/kotlin/com/assari/voicebooklm/infrastructure/postgres_jpa/memo/MemoJpaEntity.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/infrastructure/postgres_jpa/memo/MemoJpaEntity.kt
@@ -6,6 +6,7 @@ import com.assari.voicebooklm.domain.model.Transcription
 import com.assari.voicebooklm.domain.model.TranscriptionStatus
 import com.assari.voicebooklm.domain.model.VoiceMemo
 import jakarta.persistence.CollectionTable
+import org.slf4j.LoggerFactory
 import jakarta.persistence.Column
 import jakarta.persistence.ElementCollection
 import jakarta.persistence.Entity
@@ -78,23 +79,43 @@ class MemoJpaEntity(
         val transcriptionDomain = when (TranscriptionStatus.valueOf(transcriptionStatus)) {
             TranscriptionStatus.PENDING -> Transcription.pending(languageCode)
             TranscriptionStatus.PROCESSING -> Transcription.processing(languageCode)
-            TranscriptionStatus.COMPLETED -> Transcription.completed(
-                text = transcription ?: "",
-                languageCode = languageCode,
-                fallbackUsed = transcriptionFallbackUsed,
-            )
+            TranscriptionStatus.COMPLETED -> {
+                if (transcription.isNullOrBlank()) {
+                    logger.warn(
+                        "Memo id={} has COMPLETED transcription status but transcription text is null/blank. Treating as FAILED.",
+                        id
+                    )
+                    Transcription.failed(languageCode)
+                } else {
+                    Transcription.completed(
+                        text = transcription!!,
+                        languageCode = languageCode,
+                        fallbackUsed = transcriptionFallbackUsed,
+                    )
+                }
+            }
             TranscriptionStatus.FAILED -> Transcription.failed(languageCode)
         }
 
         val formattingDomain = when (FormattingStatus.valueOf(formattingStatus)) {
             FormattingStatus.PENDING -> Formatting.pending()
             FormattingStatus.PROCESSING -> Formatting.processing()
-            FormattingStatus.COMPLETED -> Formatting.completed(
-                title = title ?: "Untitled",
-                content = content ?: "",
-                tags = tags.toList(),
-                fallbackUsed = formattingFallbackUsed,
-            )
+            FormattingStatus.COMPLETED -> {
+                if (content.isNullOrBlank()) {
+                    logger.warn(
+                        "Memo id={} has COMPLETED formatting status but content is null/blank. Treating as FAILED.",
+                        id
+                    )
+                    Formatting.failed()
+                } else {
+                    Formatting.completed(
+                        title = title ?: "Untitled",
+                        content = content!!,
+                        tags = tags.toList(),
+                        fallbackUsed = formattingFallbackUsed,
+                    )
+                }
+            }
             FormattingStatus.FAILED -> Formatting.failed()
         }
 
@@ -110,6 +131,7 @@ class MemoJpaEntity(
     }
 
     companion object {
+        private val logger = LoggerFactory.getLogger(MemoJpaEntity::class.java)
         /**
          * VoiceMemo ドメインモデルからエンティティを作成
          */

--- a/src/main/kotlin/com/assari/voicebooklm/usecase/memo/CreateMemoUseCase.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/usecase/memo/CreateMemoUseCase.kt
@@ -11,6 +11,7 @@ import com.assari.voicebooklm.domain.model.VoiceMemo
 import com.assari.voicebooklm.domain.repository.VoiceMemoRepository
 import com.assari.voicebooklm.usecase.support.ExecutionTimer
 import com.assari.voicebooklm.usecase.support.MonotonicExecutionTimer
+import com.github.f4b6a3.uuid.UuidCreator
 import java.util.UUID
 import kotlin.time.Duration
 import kotlin.time.TimeSource
@@ -43,6 +44,7 @@ open class CreateMemoUseCase(
 
         // 1. VoiceMemo を作成（処理待ち状態）
         var voiceMemo = VoiceMemo.create(
+            id = UuidCreator.getTimeOrderedEpoch(),
             userId = input.userId,
             languageCode = languageCode,
         )

--- a/src/test/kotlin/com/assari/voicebooklm/domain/model/RefreshTokenTest.kt
+++ b/src/test/kotlin/com/assari/voicebooklm/domain/model/RefreshTokenTest.kt
@@ -113,10 +113,32 @@ class RefreshTokenTest {
             revoked = false
         )
 
-        refreshToken.revoke()
+        val revokedToken = refreshToken.revoke()
 
-        assertTrue(refreshToken.revoked)
-        assertFalse(refreshToken.isValid())
+        // 元のトークンは変更されない（イミュータブル）
+        assertFalse(refreshToken.revoked)
+        assertTrue(refreshToken.isValid())
+
+        // 新しいトークンは無効化されている
+        assertTrue(revokedToken.revoked)
+        assertFalse(revokedToken.isValid())
+    }
+
+    @Test
+    fun `should return same instance when already revoked`() {
+        val refreshToken = RefreshToken(
+            id = UUID.randomUUID(),
+            token = "refresh-token",
+            userId = UUID.randomUUID(),
+            expiresAt = Instant.now().plusSeconds(3600),
+            createdAt = Instant.now(),
+            revoked = true
+        )
+
+        val revokedToken = refreshToken.revoke()
+
+        // 既に無効化済みの場合は同じインスタンスを返す
+        assertSame(refreshToken, revokedToken)
     }
 
     @Test

--- a/src/test/kotlin/com/assari/voicebooklm/presentation/controller/memo/MemoControllerTest.kt
+++ b/src/test/kotlin/com/assari/voicebooklm/presentation/controller/memo/MemoControllerTest.kt
@@ -35,14 +35,14 @@ class MemoControllerTest {
     fun `認証済みユーザーのメモ一覧を返す`() = runBlocking {
         val userId = UUID.randomUUID()
         // 整形済みメモと未整形メモを混在させてレスポンス形式を確認する。
-        val completedMemo = VoiceMemo.create(userId = userId)
+        val completedMemo = VoiceMemo.create(id = UUID.randomUUID(), userId = userId)
             .completeTranscription("text")
             .completeFormatting(
                 title = "title",
                 content = "content",
                 tags = listOf("t1"),
             )
-        val pendingMemo = VoiceMemo.create(userId = userId)
+        val pendingMemo = VoiceMemo.create(id = UUID.randomUUID(), userId = userId)
         coEvery { listMemosUseCase.execute(ListMemosInput(userId)) } returns ListMemosOutput(
             memos = listOf(completedMemo, pendingMemo),
         )

--- a/src/test/kotlin/com/assari/voicebooklm/usecase/memo/ListMemosUseCaseTest.kt
+++ b/src/test/kotlin/com/assari/voicebooklm/usecase/memo/ListMemosUseCaseTest.kt
@@ -16,9 +16,9 @@ class ListMemosUseCaseTest {
     fun `ユーザーのメモ一覧を取得できる`() = runTest {
         val userId = UUID.randomUUID()
         val otherUserId = UUID.randomUUID()
-        val memo1 = VoiceMemo.create(userId = userId)
-        val memo2 = VoiceMemo.create(userId = userId)
-        val otherMemo = VoiceMemo.create(userId = otherUserId)
+        val memo1 = VoiceMemo.create(id = UUID.randomUUID(), userId = userId)
+        val memo2 = VoiceMemo.create(id = UUID.randomUUID(), userId = userId)
+        val otherMemo = VoiceMemo.create(id = UUID.randomUUID(), userId = otherUserId)
 
         val voiceMemoRepository = InMemoryVoiceMemoRepository(
             initialMemos = listOf(memo1, memo2, otherMemo),


### PR DESCRIPTION
## 関連Issue
<!-- #の後ろに対応するissue番号を書く -->
Closes #61 

## やったこと

| 項目                                        | 対応                         |
|---------------------------------------------|------------------------------|
| VoiceMemo に equals/hashCode を追加         | ID のみで比較するように      |
| init ブロックでバリデーション追加           | 不正な状態を防ぐ             |
| RefreshToken をイミュータブル化             | 設計の一貫性                 |
## 動作確認
<!-- テスト内容など -->
- [ ] ビルドできた

## 参考にした資料

