### PR TITLE
memosにfolder_pathカラム追加 #44

### DIFF
--- a/src/main/kotlin/com/assari/voicebooklm/domain/model/Folder.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/domain/model/Folder.kt
@@ -1,0 +1,96 @@
+package com.assari.voicebooklm.domain.model
+
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * フォルダードメインモデル
+ *
+ * メモを分類するためのフォルダーを表現する。
+ * 階層構造を持ち、親フォルダーへの参照を保持する。
+ * イミュータブルな設計で、変更時は新しいインスタンスを返す。
+ */
+data class Folder(
+    val id: UUID,
+    val userId: UUID,
+    val name: String,
+    val parentId: UUID?,
+    val createdAt: Instant = Instant.now(),
+    val updatedAt: Instant = Instant.now(),
+) {
+    init {
+        validate()
+    }
+
+    private fun validate() {
+        require(name.isNotBlank()) { "Folder name must not be blank" }
+        require(name.length <= MAX_NAME_LENGTH) {
+            "Folder name must not exceed $MAX_NAME_LENGTH characters"
+        }
+    }
+
+    /**
+     * フォルダー名を変更した新しい Folder インスタンスを返す
+     */
+    fun rename(newName: String): Folder = copy(
+        name = newName.trim(),
+        updatedAt = Instant.now(),
+    )
+
+    /**
+     * 親フォルダーを変更した新しい Folder インスタンスを返す
+     */
+    fun moveTo(newParentId: UUID?): Folder = copy(
+        parentId = newParentId,
+        updatedAt = Instant.now(),
+    )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Folder) return false
+        return id == other.id
+    }
+
+    override fun hashCode(): Int = id.hashCode()
+
+    companion object {
+        const val MAX_NAME_LENGTH = 50
+
+        /**
+         * 新規フォルダーを作成
+         */
+        fun create(
+            id: UUID,
+            userId: UUID,
+            name: String,
+            parentId: UUID? = null,
+        ): Folder {
+            val normalizedName = name.trim()
+            return Folder(
+                id = id,
+                userId = userId,
+                name = normalizedName,
+                parentId = parentId,
+            )
+        }
+
+        /**
+         * 永続化されたデータから復元
+         */
+        fun restore(
+            id: UUID,
+            userId: UUID,
+            name: String,
+            parentId: UUID?,
+            createdAt: Instant,
+            updatedAt: Instant,
+        ): Folder = Folder(
+            id = id,
+            userId = userId,
+            name = name,
+            parentId = parentId,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+        )
+    }
+}

--- a/src/main/kotlin/com/assari/voicebooklm/domain/model/Formatting.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/domain/model/Formatting.kt
@@ -1,5 +1,7 @@
 package com.assari.voicebooklm.domain.model
 
+import java.util.UUID
+
 /**
  * AI整形結果を表す値オブジェクト
  *
@@ -16,6 +18,8 @@ data class Formatting(
     val tags: List<String>,
     /** フォールバックが使用されたかどうか */
     val fallbackUsed: Boolean = false,
+    /** フォルダーID（未分類の場合は null） */
+    val folderId: UUID? = null,
 ) {
     init {
         validate()
@@ -71,6 +75,7 @@ data class Formatting(
             content: String,
             tags: List<String> = emptyList(),
             fallbackUsed: Boolean = false,
+            folderId: UUID? = null,
         ): Formatting {
             val normalizedTitle = title.trim()
             require(normalizedTitle.isNotBlank()) { "Formatting title must not be blank when completed" }
@@ -82,6 +87,7 @@ data class Formatting(
                 content = content,
                 tags = sanitizedTags,
                 fallbackUsed = fallbackUsed,
+                folderId = folderId,
             )
         }
 

--- a/src/main/kotlin/com/assari/voicebooklm/domain/repository/FolderRepository.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/domain/repository/FolderRepository.kt
@@ -1,0 +1,66 @@
+package com.assari.voicebooklm.domain.repository
+
+import com.assari.voicebooklm.domain.model.Folder
+import java.util.UUID
+
+/**
+ * Folder 永続化ポート
+ */
+interface FolderRepository {
+    /**
+     * フォルダーを保存する
+     */
+    suspend fun save(folder: Folder): Folder
+
+    /**
+     * ID でフォルダーを取得する
+     */
+    suspend fun findById(id: UUID): Folder?
+
+    /**
+     * ユーザーの全フォルダーを取得する
+     */
+    suspend fun findByUserId(userId: UUID): List<Folder>
+
+    /**
+     * ユーザーの特定親フォルダー直下のフォルダーを取得する
+     *
+     * @param userId ユーザーID
+     * @param parentId 親フォルダーID（null の場合はルートフォルダー直下）
+     */
+    suspend fun findByUserIdAndParentId(userId: UUID, parentId: UUID?): List<Folder>
+
+    /**
+     * パス（例: "仕事/プロジェクトA"）からフォルダーを検索する
+     *
+     * @param userId ユーザーID
+     * @param path スラッシュ区切りのフォルダーパス
+     */
+    suspend fun findByUserIdAndPath(userId: UUID, path: String): Folder?
+
+    /**
+     * 指定フォルダーの全子孫フォルダーIDを取得する
+     *
+     * @param folderId 基点となるフォルダーID
+     */
+    suspend fun findDescendantIds(folderId: UUID): List<UUID>
+
+    /**
+     * フォルダーを削除する
+     */
+    suspend fun delete(id: UUID)
+
+    /**
+     * 同一親フォルダー内に同名フォルダーが存在するかチェックする
+     *
+     * @param userId ユーザーID
+     * @param parentId 親フォルダーID（null の場合はルート直下）
+     * @param name フォルダー名
+     */
+    suspend fun existsByUserIdAndParentIdAndName(userId: UUID, parentId: UUID?, name: String): Boolean
+
+    /**
+     * ユーザーIDに紐づくすべてのフォルダーを削除する（アカウント削除用）
+     */
+    fun deleteByUserId(userId: UUID)
+}

--- a/src/main/kotlin/com/assari/voicebooklm/infrastructure/postgres_jdbc/memo/MemoEntity.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/infrastructure/postgres_jdbc/memo/MemoEntity.kt
@@ -56,6 +56,9 @@ data class MemoEntity(
 
     val deleted: Boolean,
 
+    @Column("folder_id")
+    val folderId: UUID? = null,
+
     @MappedCollection(idColumn = "memo_id")
     val tags: Set<MemoTag> = emptySet()
 ) {
@@ -100,6 +103,7 @@ data class MemoEntity(
                         content = content,
                         tags = tags.map { it.tag },
                         fallbackUsed = formattingFallbackUsed,
+                        folderId = folderId,
                     )
                 }
             }
@@ -136,6 +140,7 @@ data class MemoEntity(
                 title = voiceMemo.formatting.title,
                 content = voiceMemo.formatting.content,
                 deleted = voiceMemo.deleted,
+                folderId = voiceMemo.formatting.folderId,
                 tags = voiceMemo.formatting.tags.map { MemoTag.create(it) }.toSet(),
                 createdAt = voiceMemo.createdAt,
                 updatedAt = voiceMemo.updatedAt,

--- a/src/main/resources/db/migration/V006__add_folders_table.sql
+++ b/src/main/resources/db/migration/V006__add_folders_table.sql
@@ -1,0 +1,48 @@
+-- V006: folders テーブル追加と memos.folder_id カラム追加
+--
+-- メモにフォルダー属性を追加し、AI整形時に自動的にフォルダー分類を行う機能の基盤
+-- #44: memosにfolder属性追加
+
+-- ==============================================
+-- 1. folders テーブル作成
+-- ==============================================
+CREATE TABLE folders (
+    id UUID PRIMARY KEY,  -- アプリケーション側で UUIDv7 を生成
+    user_id UUID NOT NULL,
+    name VARCHAR(50) NOT NULL,
+    parent_id UUID,  -- NULL許可（ルートフォルダーの場合）
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_folders_user_id FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT fk_folders_parent_id FOREIGN KEY (parent_id) REFERENCES folders(id) ON DELETE CASCADE,
+    CONSTRAINT folders_unique_name UNIQUE (user_id, parent_id, name)
+);
+
+-- ユーザーのフォルダー一覧取得用インデックス
+CREATE INDEX idx_folders_user ON folders(user_id);
+
+-- 子フォルダー取得用インデックス
+CREATE INDEX idx_folders_parent ON folders(parent_id);
+
+-- ==============================================
+-- 2. memos テーブルに folder_id カラム追加
+-- ==============================================
+ALTER TABLE memos ADD COLUMN IF NOT EXISTS folder_id UUID;
+
+-- 外部キー制約（フォルダー削除時は未分類に変更）
+ALTER TABLE memos ADD CONSTRAINT fk_memos_folder_id
+    FOREIGN KEY (folder_id) REFERENCES folders(id) ON DELETE SET NULL;
+
+-- フォルダー別メモ取得用インデックス
+CREATE INDEX idx_memos_folder ON memos(folder_id) WHERE folder_id IS NOT NULL;
+
+-- ==============================================
+-- コメント追加
+-- ==============================================
+COMMENT ON TABLE folders IS 'メモ分類用フォルダー（階層構造対応）';
+COMMENT ON COLUMN folders.id IS 'フォルダー ID (UUIDv7)';
+COMMENT ON COLUMN folders.user_id IS 'ユーザー ID（外部キー）';
+COMMENT ON COLUMN folders.name IS 'フォルダー名（1〜50文字）';
+COMMENT ON COLUMN folders.parent_id IS '親フォルダー ID（NULL = ルートフォルダー）';
+
+COMMENT ON COLUMN memos.folder_id IS '所属フォルダー ID（NULL = 未分類）';


### PR DESCRIPTION
## 関連Issue
<!-- #の後ろに対応するissue番号を書く -->
Closes #44 

## やったこと

単純にmemosテーブルにfolder_pathを追加するのは実装や正規化の観点が望ましくなかった。
よってfoldersテーブルを定義した。

  | ファイル                              | 変更内容                                              |
  |---------------------------------------|-------------------------------------------------------|
  | V006__add_folders_table.sql           | folders テーブル新規作成 + memos.folder_id カラム追加 |
  | domain/model/Folder.kt                | Folder ドメインエンティティ新規作成                   |
  | domain/repository/FolderRepository.kt | FolderRepository インターフェース新規作成             |
  | domain/model/Formatting.kt            | folderId プロパティ追加                               |
  | infrastructure/.../MemoEntity.kt      | folderId カラムマッピング追加                         |

## 動作確認
<!-- テスト内容など -->
- [ ] ビルドできた

## 参考にした資料

