### PR TITLE
フォルダー削除APIを実装　#35

### DIFF
--- a/src/main/kotlin/com/assari/voicebooklm/domain/exception/DomainException.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/domain/exception/DomainException.kt
@@ -23,6 +23,7 @@ enum class ErrorCode(val httpStatus: HttpStatus, val defaultMessage: String) {
     // 競合 (409)
     FOLDER_ALREADY_EXISTS(HttpStatus.CONFLICT, "同じ名前のフォルダーが既に存在します"),
     FOLDER_HAS_CHILDREN(HttpStatus.CONFLICT, "子フォルダーが存在するため削除できません"),
+    FOLDER_HAS_MEMOS(HttpStatus.CONFLICT, "フォルダー内にメモが存在するため削除できません"),
     FOLDER_CIRCULAR_REFERENCE(HttpStatus.CONFLICT, "循環参照が発生するため移動できません"),
 
     // 処理失敗 (422)

--- a/src/main/kotlin/com/assari/voicebooklm/domain/repository/VoiceMemoRepository.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/domain/repository/VoiceMemoRepository.kt
@@ -26,4 +26,13 @@ interface VoiceMemoRepository {
      * ユーザーID に紐づくすべての VoiceMemo を削除する（アカウント削除用）
      */
     fun deleteByUserId(userId: UUID)
+
+    /**
+     * 指定フォルダー内のメモが存在するかチェックする
+     *
+     * @param userId ユーザーID
+     * @param folderId フォルダーID
+     * @return メモが存在する場合true
+     */
+    suspend fun existsByUserIdAndFolderId(userId: UUID, folderId: UUID): Boolean
 }

--- a/src/main/kotlin/com/assari/voicebooklm/infrastructure/postgres_jdbc/memo/MemoJdbcRepository.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/infrastructure/postgres_jdbc/memo/MemoJdbcRepository.kt
@@ -40,4 +40,23 @@ interface MemoJdbcRepository : CrudRepository<MemoEntity, UUID> {
     @Modifying
     @Query("DELETE FROM memos WHERE user_id = :userId")
     fun deleteByUserId(@Param("userId") userId: UUID)
+
+    /**
+     * 指定フォルダー内にメモが存在するかチェック
+     *
+     * @param userId ユーザーID
+     * @param folderId フォルダーID
+     * @return メモが存在する場合true
+     */
+    @Query("""
+        SELECT EXISTS(
+            SELECT 1 FROM memos
+            WHERE user_id = :userId AND folder_id = :folderId AND deleted = false
+            LIMIT 1
+        )
+    """)
+    fun existsByUserIdAndFolderId(
+        @Param("userId") userId: UUID,
+        @Param("folderId") folderId: UUID,
+    ): Boolean
 }

--- a/src/main/kotlin/com/assari/voicebooklm/infrastructure/postgres_jdbc/memo/MemoJdbcRepository.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/infrastructure/postgres_jdbc/memo/MemoJdbcRepository.kt
@@ -52,7 +52,6 @@ interface MemoJdbcRepository : CrudRepository<MemoEntity, UUID> {
         SELECT EXISTS(
             SELECT 1 FROM memos
             WHERE user_id = :userId AND folder_id = :folderId AND deleted = false
-            LIMIT 1
         )
     """)
     fun existsByUserIdAndFolderId(

--- a/src/main/kotlin/com/assari/voicebooklm/infrastructure/postgres_jdbc/memo/VoiceMemoRepositoryImpl.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/infrastructure/postgres_jdbc/memo/VoiceMemoRepositoryImpl.kt
@@ -34,4 +34,7 @@ class VoiceMemoRepositoryImpl(
     override fun deleteByUserId(userId: UUID) {
         memoJdbcRepository.deleteByUserId(userId)
     }
+
+    override suspend fun existsByUserIdAndFolderId(userId: UUID, folderId: UUID): Boolean =
+        memoJdbcRepository.existsByUserIdAndFolderId(userId, folderId)
 }

--- a/src/main/kotlin/com/assari/voicebooklm/presentation/controller/folder/FolderController.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/presentation/controller/folder/FolderController.kt
@@ -3,6 +3,8 @@ package com.assari.voicebooklm.presentation.controller.folder
 import com.assari.voicebooklm.presentation.controller.auth.ErrorResponse
 import com.assari.voicebooklm.usecase.folder.CreateFolderInput
 import com.assari.voicebooklm.usecase.folder.CreateFolderUseCase
+import com.assari.voicebooklm.usecase.folder.DeleteFolderInput
+import com.assari.voicebooklm.usecase.folder.DeleteFolderUseCase
 import com.assari.voicebooklm.usecase.folder.ListFoldersInput
 import com.assari.voicebooklm.usecase.folder.ListFoldersUseCase
 import com.assari.voicebooklm.usecase.folder.UpdateFolderInput
@@ -17,6 +19,7 @@ import java.util.UUID
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -35,6 +38,7 @@ class FolderController(
     private val listFoldersUseCase: ListFoldersUseCase,
     private val createFolderUseCase: CreateFolderUseCase,
     private val updateFolderUseCase: UpdateFolderUseCase,
+    private val deleteFolderUseCase: DeleteFolderUseCase,
 ) {
     @GetMapping("/folders")
     @Operation(
@@ -146,5 +150,37 @@ class FolderController(
             )
         )
         return ResponseEntity.ok(FolderResponse.from(result.folder, result.path))
+    }
+
+    @DeleteMapping("/folders/{id}")
+    @Operation(
+        summary = "フォルダー削除",
+        description = "フォルダーを削除する。子フォルダーまたはメモが存在する場合は削除できない。",
+        responses = [
+            ApiResponse(responseCode = "204", description = "削除成功"),
+            ApiResponse(
+                responseCode = "401",
+                description = "認証エラー",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "フォルダーが見つからない",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "子フォルダーまたはメモが存在するため削除できない",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            ),
+        ],
+    )
+    suspend fun deleteFolder(
+        @AuthenticationPrincipal userId: UUID?,
+        @PathVariable id: UUID,
+    ): ResponseEntity<Void> {
+        userId ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+        deleteFolderUseCase.execute(DeleteFolderInput(userId = userId, folderId = id))
+        return ResponseEntity.noContent().build()
     }
 }

--- a/src/main/kotlin/com/assari/voicebooklm/usecase/folder/DeleteFolderUseCase.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/usecase/folder/DeleteFolderUseCase.kt
@@ -1,0 +1,62 @@
+package com.assari.voicebooklm.usecase.folder
+
+import com.assari.voicebooklm.domain.exception.DomainException
+import com.assari.voicebooklm.domain.exception.ErrorCode
+import com.assari.voicebooklm.domain.repository.FolderRepository
+import com.assari.voicebooklm.domain.repository.VoiceMemoRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+/**
+ * フォルダー削除ユースケース
+ *
+ * 子フォルダーまたはメモが存在する場合は削除できない。
+ */
+@Service
+open class DeleteFolderUseCase(
+    private val folderRepository: FolderRepository,
+    private val voiceMemoRepository: VoiceMemoRepository,
+) {
+    @Transactional
+    open suspend fun execute(input: DeleteFolderInput) {
+        // 1. フォルダーの存在確認
+        val folder = folderRepository.findById(input.folderId)
+            ?: throw DomainException(ErrorCode.FOLDER_NOT_FOUND, "フォルダーが見つかりません: ${input.folderId}")
+
+        // 2. ユーザー権限チェック
+        if (folder.userId != input.userId) {
+            throw DomainException(ErrorCode.FOLDER_NOT_FOUND, "フォルダーが見つかりません: ${input.folderId}")
+        }
+
+        // 3. 子フォルダーの存在チェック
+        val descendantIds = folderRepository.findDescendantIds(input.folderId)
+        if (descendantIds.isNotEmpty()) {
+            throw DomainException(
+                ErrorCode.FOLDER_HAS_CHILDREN,
+                "子フォルダーが存在するため削除できません"
+            )
+        }
+
+        // 4. メモの存在チェック
+        val hasMemos = voiceMemoRepository.existsByUserIdAndFolderId(input.userId, input.folderId)
+        if (hasMemos) {
+            throw DomainException(
+                ErrorCode.FOLDER_HAS_MEMOS,
+                "フォルダー内にメモが存在するため削除できません"
+            )
+        }
+
+        // 5. フォルダー削除
+        folderRepository.delete(input.folderId)
+    }
+}
+
+/**
+ * フォルダー削除Input
+ */
+data class DeleteFolderInput(
+    val userId: UUID,
+    val folderId: UUID,
+)
+

--- a/src/test/kotlin/com/assari/voicebooklm/usecase/folder/DeleteFolderUseCaseTest.kt
+++ b/src/test/kotlin/com/assari/voicebooklm/usecase/folder/DeleteFolderUseCaseTest.kt
@@ -1,0 +1,196 @@
+package com.assari.voicebooklm.usecase.folder
+
+import com.assari.voicebooklm.domain.exception.DomainException
+import com.assari.voicebooklm.domain.exception.ErrorCode
+import com.assari.voicebooklm.domain.model.Folder
+import com.assari.voicebooklm.domain.model.Formatting
+import com.assari.voicebooklm.domain.model.FormattingStatus
+import com.assari.voicebooklm.domain.model.Transcription
+import com.assari.voicebooklm.domain.model.TranscriptionStatus
+import com.assari.voicebooklm.domain.model.VoiceMemo
+import com.assari.voicebooklm.usecase.memo.InMemoryVoiceMemoRepository
+import java.time.Instant
+import java.util.UUID
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * DeleteFolderUseCase の振る舞いをテストダブルで検証。
+ */
+class DeleteFolderUseCaseTest {
+
+    @Test
+    fun `空のフォルダーを削除できる`() = runTest {
+        val userId = UUID.randomUUID()
+        val folder = Folder.create(
+            id = UUID.randomUUID(),
+            userId = userId,
+            name = "仕事",
+            parentId = null,
+        )
+        val folderRepository = InMemoryFolderRepository(initialFolders = listOf(folder))
+        val voiceMemoRepository = InMemoryVoiceMemoRepository()
+        val useCase = DeleteFolderUseCase(folderRepository, voiceMemoRepository)
+
+        useCase.execute(DeleteFolderInput(userId = userId, folderId = folder.id))
+
+        // フォルダーが削除されていることを確認
+        assertNull(folderRepository.findById(folder.id))
+    }
+
+    @Test
+    fun `存在しないフォルダーを削除しようとするとFOLDER_NOT_FOUNDエラーになる`() = runTest {
+        val userId = UUID.randomUUID()
+        val nonExistentFolderId = UUID.randomUUID()
+
+        val folderRepository = InMemoryFolderRepository()
+        val voiceMemoRepository = InMemoryVoiceMemoRepository()
+        val useCase = DeleteFolderUseCase(folderRepository, voiceMemoRepository)
+
+        val exception = assertThrows<DomainException> {
+            useCase.execute(DeleteFolderInput(userId = userId, folderId = nonExistentFolderId))
+        }
+
+        assertEquals(ErrorCode.FOLDER_NOT_FOUND, exception.code)
+    }
+
+    @Test
+    fun `他人のフォルダーを削除しようとするとFOLDER_NOT_FOUNDエラーになる`() = runTest {
+        val ownerId = UUID.randomUUID()
+        val otherUserId = UUID.randomUUID()
+        val folder = Folder.create(
+            id = UUID.randomUUID(),
+            userId = ownerId,
+            name = "仕事",
+            parentId = null,
+        )
+
+        val folderRepository = InMemoryFolderRepository(initialFolders = listOf(folder))
+        val voiceMemoRepository = InMemoryVoiceMemoRepository()
+        val useCase = DeleteFolderUseCase(folderRepository, voiceMemoRepository)
+
+        val exception = assertThrows<DomainException> {
+            useCase.execute(DeleteFolderInput(userId = otherUserId, folderId = folder.id))
+        }
+
+        assertEquals(ErrorCode.FOLDER_NOT_FOUND, exception.code)
+
+        // フォルダーは削除されていないことを確認
+        assertEquals(folder, folderRepository.findById(folder.id))
+    }
+
+    @Test
+    fun `子フォルダーが存在する場合は削除できない`() = runTest {
+        val userId = UUID.randomUUID()
+        val parentFolder = Folder.create(
+            id = UUID.randomUUID(),
+            userId = userId,
+            name = "仕事",
+            parentId = null,
+        )
+        val childFolder = Folder.create(
+            id = UUID.randomUUID(),
+            userId = userId,
+            name = "プロジェクトA",
+            parentId = parentFolder.id,
+        )
+
+        val folderRepository = InMemoryFolderRepository(initialFolders = listOf(parentFolder, childFolder))
+        val voiceMemoRepository = InMemoryVoiceMemoRepository()
+        val useCase = DeleteFolderUseCase(folderRepository, voiceMemoRepository)
+
+        val exception = assertThrows<DomainException> {
+            useCase.execute(DeleteFolderInput(userId = userId, folderId = parentFolder.id))
+        }
+
+        assertEquals(ErrorCode.FOLDER_HAS_CHILDREN, exception.code)
+
+        // フォルダーは削除されていないことを確認
+        assertEquals(parentFolder, folderRepository.findById(parentFolder.id))
+        assertEquals(childFolder, folderRepository.findById(childFolder.id))
+    }
+
+    @Test
+    fun `メモが存在する場合は削除できない`() = runTest {
+        val userId = UUID.randomUUID()
+        val folder = Folder.create(
+            id = UUID.randomUUID(),
+            userId = userId,
+            name = "仕事",
+            parentId = null,
+        )
+        val memo = VoiceMemo.restore(
+            id = UUID.randomUUID(),
+            userId = userId,
+            transcription = Transcription.completed("テスト", "ja-JP"),
+            formatting = Formatting.completed(
+                title = "テストメモ",
+                content = "テスト内容",
+                tags = emptyList(),
+                folderId = folder.id,
+            ),
+            deleted = false,
+            createdAt = Instant.now(),
+            updatedAt = Instant.now(),
+        )
+
+        val folderRepository = InMemoryFolderRepository(initialFolders = listOf(folder))
+        val voiceMemoRepository = InMemoryVoiceMemoRepository(initialMemos = listOf(memo))
+        val useCase = DeleteFolderUseCase(folderRepository, voiceMemoRepository)
+
+        val exception = assertThrows<DomainException> {
+            useCase.execute(DeleteFolderInput(userId = userId, folderId = folder.id))
+        }
+
+        assertEquals(ErrorCode.FOLDER_HAS_MEMOS, exception.code)
+
+        // フォルダーは削除されていないことを確認
+        assertEquals(folder, folderRepository.findById(folder.id))
+    }
+
+    @Test
+    fun `子フォルダーとメモの両方が存在する場合は子フォルダーのエラーが優先される`() = runTest {
+        val userId = UUID.randomUUID()
+        val parentFolder = Folder.create(
+            id = UUID.randomUUID(),
+            userId = userId,
+            name = "仕事",
+            parentId = null,
+        )
+        val childFolder = Folder.create(
+            id = UUID.randomUUID(),
+            userId = userId,
+            name = "プロジェクトA",
+            parentId = parentFolder.id,
+        )
+        val memo = VoiceMemo.restore(
+            id = UUID.randomUUID(),
+            userId = userId,
+            transcription = Transcription.completed("テスト", "ja-JP"),
+            formatting = Formatting.completed(
+                title = "テストメモ",
+                content = "テスト内容",
+                tags = emptyList(),
+                folderId = parentFolder.id,
+            ),
+            deleted = false,
+            createdAt = Instant.now(),
+            updatedAt = Instant.now(),
+        )
+
+        val folderRepository = InMemoryFolderRepository(initialFolders = listOf(parentFolder, childFolder))
+        val voiceMemoRepository = InMemoryVoiceMemoRepository(initialMemos = listOf(memo))
+        val useCase = DeleteFolderUseCase(folderRepository, voiceMemoRepository)
+
+        val exception = assertThrows<DomainException> {
+            useCase.execute(DeleteFolderInput(userId = userId, folderId = parentFolder.id))
+        }
+
+        // 子フォルダーのチェックが先に行われるため、FOLDER_HAS_CHILDRENエラーになる
+        assertEquals(ErrorCode.FOLDER_HAS_CHILDREN, exception.code)
+    }
+}
+

--- a/src/test/kotlin/com/assari/voicebooklm/usecase/memo/InMemoryVoiceMemoRepository.kt
+++ b/src/test/kotlin/com/assari/voicebooklm/usecase/memo/InMemoryVoiceMemoRepository.kt
@@ -33,6 +33,9 @@ internal class InMemoryVoiceMemoRepository(
         memos.removeIf { it.userId == userId }
     }
 
+    override suspend fun existsByUserIdAndFolderId(userId: UUID, folderId: UUID): Boolean =
+        memos.any { it.userId == userId && it.formatting.folderId == folderId && !it.deleted }
+
     /**
      * テスト用：削除済みメモも含めて取得するメソッド
      */


### PR DESCRIPTION
- DELETE /api/folders/{id} エンドポイントを追加
- 子フォルダーまたはメモが存在する場合は409エラーを返す
- VoiceMemoRepositoryにメモ存在チェックメソッドを追加
- FOLDER_HAS_MEMOSエラーコードを追加
- テストを追加（6テストケース）
- Swaggerでメモ削除を拒否の挙動と、削除成功の動作確認済み

## 関連Issue
<!-- #の後ろに対応するissue番号を書く -->
Closes #35 

## やったこと

- `DELETE /api/folders/{id}` エンドポイントを実装
- フォルダー削除前に子フォルダーとメモの存在チェックを実装
- `VoiceMemoRepository.existsByUserIdAndFolderId`メソッドを追加
- `FOLDER_HAS_MEMOS`エラーコードを追加（409 CONFLICT）
- `DeleteFolderUseCase`とテストを実装

## 動作確認
<!-- テスト内容など -->
- [x] ビルドできた
- [x] ユニットテストが通る
- [x] Swaggerで動作確認済み（画像参照）
<img width="1405" height="668" alt="フォルダ削除APIテスト 成功" src="https://github.com/user-attachments/assets/f15e9cbf-35ae-45a1-9273-66aafd2cae26" />
<img width="1412" height="550" alt="フォルダ削除APIテスト メモがある場合" src="https://github.com/user-attachments/assets/f415f021-9287-4b1c-b3cd-655bdc1bff12" />


## 参考にした資料
