### PR TITLE
メモ再要約機能を実装 #28

### DIFF
--- a/src/main/kotlin/com/assari/voicebooklm/domain/exception/DomainException.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/domain/exception/DomainException.kt
@@ -28,6 +28,8 @@ enum class ErrorCode(val httpStatus: HttpStatus, val defaultMessage: String) {
 
     // 処理失敗 (422)
     TRANSCRIPTION_FAILED(HttpStatus.UNPROCESSABLE_ENTITY, "音声の文字起こしに失敗しました"),
+    TRANSCRIPTION_NOT_COMPLETED(HttpStatus.UNPROCESSABLE_ENTITY, "文字起こしが完了していないため編集できません"),
+    INVALID_TRANSCRIPTION(HttpStatus.UNPROCESSABLE_ENTITY, "文字起こしテキストが空です"),
     MEMO_NOT_COMPLETED(HttpStatus.UNPROCESSABLE_ENTITY, "メモの整形が完了していないため編集できません"),
 }
 

--- a/src/main/kotlin/com/assari/voicebooklm/presentation/controller/memo/MemoController.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/presentation/controller/memo/MemoController.kt
@@ -8,6 +8,8 @@ import com.assari.voicebooklm.usecase.memo.GetMemoUseCase
 import com.assari.voicebooklm.usecase.memo.ListMemosInput
 import com.assari.voicebooklm.usecase.memo.ListMemosUseCase
 import com.assari.voicebooklm.usecase.memo.MemoSortField
+import com.assari.voicebooklm.usecase.memo.ResummarizeInput
+import com.assari.voicebooklm.usecase.memo.ResummarizeUseCase
 import com.assari.voicebooklm.usecase.memo.SortOrder
 import com.assari.voicebooklm.usecase.memo.UpdateMemoInput
 import com.assari.voicebooklm.usecase.memo.UpdateMemoUseCase
@@ -26,6 +28,7 @@ import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -43,6 +46,7 @@ class MemoController(
     private val getMemoUseCase: GetMemoUseCase,
     private val updateMemoUseCase: UpdateMemoUseCase,
     private val deleteMemoUseCase: DeleteMemoUseCase,
+    private val resummarizeUseCase: ResummarizeUseCase,
 ) {
     @GetMapping("/memos")
     @Operation(
@@ -254,5 +258,60 @@ class MemoController(
 
         // 204 No Content を返却
         return ResponseEntity.noContent().build()
+    }
+
+    @PostMapping("/memos/{id}/resummarize")
+    @Operation(
+        summary = "メモ再要約",
+        description = "編集された文字起こしテキストから再度AI整形（要約）を行います。",
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "再要約成功",
+                content = [Content(schema = Schema(implementation = MemoDetailResponse::class))],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "バリデーションエラー",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "認証失敗",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "メモが見つからない（存在しない、削除済み、または権限なし）",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+            ),
+            ApiResponse(
+                responseCode = "422",
+                description = "処理エラー（整形失敗など）",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+            ),
+        ],
+    )
+    suspend fun resummarize(
+        @PathVariable id: UUID,
+        @AuthenticationPrincipal userId: UUID?,
+        @Valid @RequestBody request: ResummarizeRequest,
+    ): ResponseEntity<MemoDetailResponse> {
+        // 認証チェック
+        if (userId == null) {
+            throw ResponseStatusException(HttpStatus.UNAUTHORIZED, "認証が必要です")
+        }
+
+        // ユースケース実行
+        val result = resummarizeUseCase.execute(
+            ResummarizeInput(
+                memoId = id,
+                userId = userId,
+                editedTranscription = request.editedTranscription,
+            )
+        )
+
+        // レスポンス返却
+        return ResponseEntity.ok(MemoDetailResponse.from(result))
     }
 }

--- a/src/main/kotlin/com/assari/voicebooklm/presentation/controller/memo/MemoRequest.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/presentation/controller/memo/MemoRequest.kt
@@ -1,5 +1,6 @@
 package com.assari.voicebooklm.presentation.controller.memo
 
+import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 
 /**
@@ -14,4 +15,12 @@ data class UpdateMemoRequest(
     val content: String? = null,
 
     val tags: List<String>? = null,
+)
+
+/**
+ * 再要約リクエスト
+ */
+data class ResummarizeRequest(
+    @field:NotBlank(message = "編集された文字起こしテキストは必須です")
+    val editedTranscription: String,
 )

--- a/src/main/kotlin/com/assari/voicebooklm/presentation/controller/memo/MemoResponse.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/presentation/controller/memo/MemoResponse.kt
@@ -3,6 +3,7 @@ package com.assari.voicebooklm.presentation.controller.memo
 import com.assari.voicebooklm.usecase.memo.GetMemoOutput
 import com.assari.voicebooklm.usecase.memo.ListMemosOutput
 import com.assari.voicebooklm.usecase.memo.MemoWithFolder
+import com.assari.voicebooklm.usecase.memo.ResummarizeOutput
 import com.assari.voicebooklm.usecase.memo.UpdateMemoOutput
 import java.time.Instant
 import java.util.UUID
@@ -101,6 +102,21 @@ data class MemoDetailResponse(
 
         fun from(result: UpdateMemoOutput): MemoDetailResponse {
             val memo = result.memo
+            return MemoDetailResponse(
+                memoId = memo.id,
+                title = memo.title,
+                content = memo.content,
+                tags = memo.tags,
+                transcriptionText = memo.transcriptionText,
+                transcriptionStatus = memo.transcription.status.name,
+                formattingStatus = memo.formatting.status.name,
+                createdAt = memo.createdAt,
+                updatedAt = memo.updatedAt,
+            )
+        }
+
+        fun from(result: ResummarizeOutput): MemoDetailResponse {
+            val memo = result.voiceMemo
             return MemoDetailResponse(
                 memoId = memo.id,
                 title = memo.title,

--- a/src/main/kotlin/com/assari/voicebooklm/usecase/memo/ResummarizeUseCase.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/usecase/memo/ResummarizeUseCase.kt
@@ -3,6 +3,7 @@ package com.assari.voicebooklm.usecase.memo
 import com.assari.voicebooklm.domain.exception.DomainException
 import com.assari.voicebooklm.domain.exception.ErrorCode
 import com.assari.voicebooklm.domain.gateway.MemoFormatCommand
+import com.assari.voicebooklm.domain.gateway.MemoFormatResult
 import com.assari.voicebooklm.domain.gateway.MemoFormatter
 import com.assari.voicebooklm.domain.model.VoiceMemo
 import com.assari.voicebooklm.domain.model.buildPath
@@ -20,33 +21,33 @@ import kotlin.time.Duration
  * 編集された文字起こしテキストから再要約するユースケース
  */
 @Service
-class ResummarizeUseCase(
+open class ResummarizeUseCase(
     private val voiceMemoRepository: VoiceMemoRepository,
     private val folderRepository: FolderRepository,
     private val folderPathResolver: FolderPathResolver,
     private val memoFormatter: MemoFormatter,
     private val executionTimer: ExecutionTimer,
 ) {
-    companion object {
-        private val logger = LoggerFactory.getLogger(ResummarizeUseCase::class.java)
-    }
+    private val logger = LoggerFactory.getLogger(ResummarizeUseCase::class.java)
 
     @Transactional
     open suspend fun execute(input: ResummarizeInput): ResummarizeOutput {
         // 1. メモの取得と権限チェック
         val voiceMemo = voiceMemoRepository.findById(input.memoId)
-            ?: throw DomainException(ErrorCode.MEMO_NOT_FOUND, "メモが見つかりません")
+            ?: throw DomainException(ErrorCode.MEMO_NOT_FOUND)
 
         if (voiceMemo.userId != input.userId) {
-            throw DomainException(ErrorCode.MEMO_NOT_FOUND, "メモが見つかりません")
+            throw DomainException(ErrorCode.MEMO_NOT_FOUND)
         }
 
         if (voiceMemo.deleted) {
-            throw DomainException(ErrorCode.MEMO_NOT_FOUND, "メモが見つかりません")
+            throw DomainException(ErrorCode.MEMO_NOT_FOUND)
         }
 
         // 2. 文字起こしテキストが空でないことを確認
-        require(input.editedTranscription.isNotBlank()) { "文字起こしテキストが空です" }
+        if (input.editedTranscription.isBlank()) {
+            throw DomainException(ErrorCode.INVALID_TRANSCRIPTION)
+        }
 
         // 3. 既存フォルダーパスを取得（AI整形用）
         val existingFolderPaths = getExistingFolderPaths(input.userId)
@@ -84,6 +85,9 @@ class ResummarizeUseCase(
         )
 
         // 7. 文字起こしテキストも更新
+        if (!updatedMemo.transcription.isCompleted) {
+            throw DomainException(ErrorCode.TRANSCRIPTION_NOT_COMPLETED)
+        }
         updatedMemo = updatedMemo.editTranscription(input.editedTranscription)
 
         // 8. 永続化
@@ -119,8 +123,8 @@ class ResummarizeUseCase(
         }.getOrNull()
     }
 
-    private fun fallbackFormatResult(transcriptionText: String): com.assari.voicebooklm.domain.gateway.MemoFormatResult {
-        return com.assari.voicebooklm.domain.gateway.MemoFormatResult(
+    private fun fallbackFormatResult(transcriptionText: String): MemoFormatResult {
+        return MemoFormatResult(
             title = "ボイスメモ",
             content = transcriptionText,
             tags = emptyList(),

--- a/src/main/kotlin/com/assari/voicebooklm/usecase/memo/ResummarizeUseCase.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/usecase/memo/ResummarizeUseCase.kt
@@ -1,0 +1,147 @@
+package com.assari.voicebooklm.usecase.memo
+
+import com.assari.voicebooklm.domain.exception.DomainException
+import com.assari.voicebooklm.domain.exception.ErrorCode
+import com.assari.voicebooklm.domain.gateway.MemoFormatCommand
+import com.assari.voicebooklm.domain.gateway.MemoFormatter
+import com.assari.voicebooklm.domain.model.VoiceMemo
+import com.assari.voicebooklm.domain.model.buildPath
+import com.assari.voicebooklm.domain.repository.FolderRepository
+import com.assari.voicebooklm.domain.repository.VoiceMemoRepository
+import com.assari.voicebooklm.infrastructure.service.FolderPathResolver
+import com.assari.voicebooklm.usecase.support.ExecutionTimer
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+import kotlin.time.Duration
+
+/**
+ * 編集された文字起こしテキストから再要約するユースケース
+ */
+@Service
+class ResummarizeUseCase(
+    private val voiceMemoRepository: VoiceMemoRepository,
+    private val folderRepository: FolderRepository,
+    private val folderPathResolver: FolderPathResolver,
+    private val memoFormatter: MemoFormatter,
+    private val executionTimer: ExecutionTimer,
+) {
+    companion object {
+        private val logger = LoggerFactory.getLogger(ResummarizeUseCase::class.java)
+    }
+
+    @Transactional
+    open suspend fun execute(input: ResummarizeInput): ResummarizeOutput {
+        // 1. メモの取得と権限チェック
+        val voiceMemo = voiceMemoRepository.findById(input.memoId)
+            ?: throw DomainException(ErrorCode.MEMO_NOT_FOUND, "メモが見つかりません")
+
+        if (voiceMemo.userId != input.userId) {
+            throw DomainException(ErrorCode.MEMO_NOT_FOUND, "メモが見つかりません")
+        }
+
+        if (voiceMemo.deleted) {
+            throw DomainException(ErrorCode.MEMO_NOT_FOUND, "メモが見つかりません")
+        }
+
+        // 2. 文字起こしテキストが空でないことを確認
+        require(input.editedTranscription.isNotBlank()) { "文字起こしテキストが空です" }
+
+        // 3. 既存フォルダーパスを取得（AI整形用）
+        val existingFolderPaths = getExistingFolderPaths(input.userId)
+
+        // 4. AI整形処理（再要約）
+        var updatedMemo = voiceMemo.startFormatting()
+        val formatResult = executionTimer.measure {
+            runCatching {
+                memoFormatter.format(
+                    MemoFormatCommand(
+                        userId = input.userId,
+                        transcript = input.editedTranscription,
+                        existingFolderPaths = existingFolderPaths,
+                    ),
+                )
+            }.onFailure { ex ->
+                logger.warn("AI memo formatting failed; fallback will be used", ex)
+            }.getOrElse {
+                fallbackFormatResult(input.editedTranscription)
+            }
+        }
+        val memoFormat = formatResult.value
+
+        // 5. フォルダーパスをIDに解決（必要に応じて作成）
+        val folderId = resolveFolderId(input.userId, memoFormat.folderPath)
+
+        // 6. 整形結果を適用
+        val formattingFallbackUsed = memoFormat.title == "ボイスメモ" && memoFormat.tags.isEmpty()
+        updatedMemo = updatedMemo.completeFormatting(
+            title = memoFormat.title,
+            content = memoFormat.content,
+            tags = memoFormat.tags,
+            fallbackUsed = formattingFallbackUsed,
+            folderId = folderId,
+        )
+
+        // 7. 文字起こしテキストも更新
+        updatedMemo = updatedMemo.editTranscription(input.editedTranscription)
+
+        // 8. 永続化
+        val savedMemo = voiceMemoRepository.save(updatedMemo)
+
+        return ResummarizeOutput(
+            voiceMemo = savedMemo,
+            formattingDuration = formatResult.duration,
+        )
+    }
+
+    /**
+     * ユーザーの既存フォルダーパス一覧を取得する
+     */
+    private suspend fun getExistingFolderPaths(userId: UUID): List<String> {
+        val folders = folderRepository.findByUserId(userId)
+        if (folders.isEmpty()) return emptyList()
+
+        val folderMap = folders.associateBy { it.id }
+        return folders.map { folder -> folder.buildPath(folderMap) }.sorted()
+    }
+
+    /**
+     * フォルダーパスをIDに解決する（必要に応じて作成）
+     */
+    private suspend fun resolveFolderId(userId: UUID, folderPath: String?): UUID? {
+        if (folderPath.isNullOrBlank()) return null
+
+        return runCatching {
+            folderPathResolver.resolveOrCreate(userId, folderPath)
+        }.onFailure { ex ->
+            logger.warn("Failed to resolve folder path: $folderPath", ex)
+        }.getOrNull()
+    }
+
+    private fun fallbackFormatResult(transcriptionText: String): com.assari.voicebooklm.domain.gateway.MemoFormatResult {
+        return com.assari.voicebooklm.domain.gateway.MemoFormatResult(
+            title = "ボイスメモ",
+            content = transcriptionText,
+            tags = emptyList(),
+            folderPath = null,
+        )
+    }
+}
+
+/**
+ * 再要約入力
+ */
+data class ResummarizeInput(
+    val memoId: UUID,
+    val userId: UUID,
+    val editedTranscription: String,
+)
+
+/**
+ * 再要約出力
+ */
+data class ResummarizeOutput(
+    val voiceMemo: VoiceMemo,
+    val formattingDuration: Duration,
+)

--- a/src/test/kotlin/com/assari/voicebooklm/presentation/controller/memo/MemoControllerTest.kt
+++ b/src/test/kotlin/com/assari/voicebooklm/presentation/controller/memo/MemoControllerTest.kt
@@ -12,6 +12,7 @@ import com.assari.voicebooklm.usecase.memo.ListMemosInput
 import com.assari.voicebooklm.usecase.memo.ListMemosOutput
 import com.assari.voicebooklm.usecase.memo.ListMemosUseCase
 import com.assari.voicebooklm.usecase.memo.MemoWithFolder
+import com.assari.voicebooklm.usecase.memo.ResummarizeUseCase
 import com.assari.voicebooklm.usecase.memo.UpdateMemoInput
 import com.assari.voicebooklm.usecase.memo.UpdateMemoOutput
 import com.assari.voicebooklm.usecase.memo.UpdateMemoUseCase
@@ -38,6 +39,7 @@ class MemoControllerTest {
     private lateinit var getMemoUseCase: GetMemoUseCase
     private lateinit var updateMemoUseCase: UpdateMemoUseCase
     private lateinit var deleteMemoUseCase: DeleteMemoUseCase
+    private lateinit var resummarizeUseCase: ResummarizeUseCase
     private lateinit var controller: MemoController
 
     @BeforeEach
@@ -46,11 +48,13 @@ class MemoControllerTest {
         getMemoUseCase = mockk()
         updateMemoUseCase = mockk()
         deleteMemoUseCase = mockk()
+        resummarizeUseCase = mockk()
         controller = MemoController(
             listMemosUseCase = listMemosUseCase,
             getMemoUseCase = getMemoUseCase,
             updateMemoUseCase = updateMemoUseCase,
             deleteMemoUseCase = deleteMemoUseCase,
+            resummarizeUseCase = resummarizeUseCase,
         )
     }
 

--- a/src/test/kotlin/com/assari/voicebooklm/usecase/memo/CreateMemoUseCaseTest.kt
+++ b/src/test/kotlin/com/assari/voicebooklm/usecase/memo/CreateMemoUseCaseTest.kt
@@ -158,7 +158,7 @@ class CreateMemoUseCaseTest {
     }
 }
 
-private class FakeSpeechTranscriber(
+internal class FakeSpeechTranscriber(
     private val transcript: String,
 ) : SpeechTranscriber {
     var receivedCommand: SpeechTranscriptionCommand? = null
@@ -172,7 +172,7 @@ private class FakeSpeechTranscriber(
     }
 }
 
-private class FakeMemoFormatter(
+internal class FakeMemoFormatter(
     private val title: String,
     private val content: String,
     private val tags: List<String>,
@@ -191,7 +191,7 @@ private class FakeMemoFormatter(
     }
 }
 
-private class FakeVoiceMemoRepository : VoiceMemoRepository {
+internal class FakeVoiceMemoRepository : VoiceMemoRepository {
     val savedMemos = mutableListOf<VoiceMemo>()
 
     override suspend fun save(voiceMemo: VoiceMemo): VoiceMemo {
@@ -218,7 +218,7 @@ private class FakeVoiceMemoRepository : VoiceMemoRepository {
         savedMemos.any { it.userId == userId && it.formatting.folderId == folderId && !it.deleted }
 }
 
-private class FakeFolderRepository : FolderRepository {
+internal class FakeFolderRepository : FolderRepository {
     val savedFolders = mutableListOf<Folder>()
 
     override suspend fun save(folder: Folder): Folder {
@@ -260,7 +260,7 @@ private class FakeFolderRepository : FolderRepository {
     }
 }
 
-private class FakeExecutionTimer(
+internal class FakeExecutionTimer(
     private val timeSource: TestTimeSource,
     durations: List<Duration>,
 ) : ExecutionTimer {
@@ -274,7 +274,7 @@ private class FakeExecutionTimer(
     }
 }
 
-private suspend inline fun <reified T : Throwable> assertThrowsSuspend(
+internal suspend inline fun <reified T : Throwable> assertThrowsSuspend(
     noinline block: suspend () -> Unit,
 ): T {
     try {

--- a/src/test/kotlin/com/assari/voicebooklm/usecase/memo/ResummarizeUseCaseTest.kt
+++ b/src/test/kotlin/com/assari/voicebooklm/usecase/memo/ResummarizeUseCaseTest.kt
@@ -1,0 +1,459 @@
+package com.assari.voicebooklm.usecase.memo
+
+import com.assari.voicebooklm.domain.exception.DomainException
+import com.assari.voicebooklm.domain.gateway.MemoFormatCommand
+import com.assari.voicebooklm.domain.gateway.MemoFormatResult
+import com.assari.voicebooklm.domain.gateway.MemoFormatter
+import com.assari.voicebooklm.domain.model.Folder
+import com.assari.voicebooklm.domain.model.VoiceMemo
+import com.assari.voicebooklm.infrastructure.service.FolderPathResolver
+import java.util.UUID
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.ExperimentalTime
+import kotlin.time.TestTimeSource
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * ResummarizeUseCase の振る舞いをテストダブルで検証
+ */
+@OptIn(ExperimentalTime::class)
+class ResummarizeUseCaseTest {
+
+    @Test
+    fun `再要約が成功する`() = runTest {
+        val userId = UUID.randomUUID()
+        val memoId = UUID.randomUUID()
+
+        // 既存のメモを作成
+        val existingMemo = VoiceMemo.create(
+            id = memoId,
+            userId = userId,
+            languageCode = "ja-JP",
+        )
+            .startTranscription()
+            .completeTranscription(text = "元の文字起こし", fallbackUsed = false)
+            .startFormatting()
+            .completeFormatting(
+                title = "元のタイトル",
+                content = "元の内容",
+                tags = listOf("old-tag"),
+                fallbackUsed = false,
+                folderId = null,
+            )
+
+        val voiceMemoRepository = FakeVoiceMemoRepository()
+        voiceMemoRepository.save(existingMemo)
+
+        val folderRepository = FakeFolderRepository()
+        val memoFormatter = FakeMemoFormatter(
+            title = "新しいタイトル",
+            content = "新しい内容",
+            tags = listOf("new-tag"),
+            folderPath = null,
+        )
+        val executionTimer = FakeExecutionTimer(
+            timeSource = TestTimeSource(),
+            durations = listOf(150.milliseconds),
+        )
+
+        val useCase = ResummarizeUseCase(
+            voiceMemoRepository = voiceMemoRepository,
+            folderRepository = folderRepository,
+            folderPathResolver = FolderPathResolver(folderRepository),
+            memoFormatter = memoFormatter,
+            executionTimer = executionTimer,
+        )
+
+        // 実行
+        val result = useCase.execute(
+            ResummarizeInput(
+                memoId = memoId,
+                userId = userId,
+                editedTranscription = "編集された文字起こし",
+            ),
+        )
+
+        // 検証
+        assertEquals(memoId, result.voiceMemo.id)
+        assertEquals("新しいタイトル", result.voiceMemo.title)
+        assertEquals("新しい内容", result.voiceMemo.content)
+        assertEquals(listOf("new-tag"), result.voiceMemo.tags)
+        assertEquals("編集された文字起こし", result.voiceMemo.transcriptionText)
+        assertEquals(150.milliseconds, result.formattingDuration)
+
+        // MemoFormatterに渡されたコマンドを確認
+        assertNotNull(memoFormatter.receivedCommand)
+        assertEquals("編集された文字起こし", memoFormatter.receivedCommand?.transcript)
+        assertEquals(userId, memoFormatter.receivedCommand?.userId)
+    }
+
+    @Test
+    fun `他人のメモの場合は例外を返す`() = runTest {
+        val userId = UUID.randomUUID()
+        val otherUserId = UUID.randomUUID()
+        val memoId = UUID.randomUUID()
+
+        // 他人のメモを作成
+        val otherUserMemo = VoiceMemo.create(
+            id = memoId,
+            userId = otherUserId,
+            languageCode = "ja-JP",
+        )
+            .startTranscription()
+            .completeTranscription(text = "文字起こし", fallbackUsed = false)
+            .startFormatting()
+            .completeFormatting(
+                title = "タイトル",
+                content = "内容",
+                tags = emptyList(),
+                fallbackUsed = false,
+                folderId = null,
+            )
+
+        val voiceMemoRepository = FakeVoiceMemoRepository()
+        voiceMemoRepository.save(otherUserMemo)
+
+        val folderRepository = FakeFolderRepository()
+        val useCase = ResummarizeUseCase(
+            voiceMemoRepository = voiceMemoRepository,
+            folderRepository = folderRepository,
+            folderPathResolver = FolderPathResolver(folderRepository),
+            memoFormatter = FakeMemoFormatter("", "", emptyList()),
+            executionTimer = FakeExecutionTimer(TestTimeSource(), emptyList()),
+        )
+
+        // 実行して例外を確認
+        assertThrowsSuspend<DomainException> {
+            useCase.execute(
+                ResummarizeInput(
+                    memoId = memoId,
+                    userId = userId,
+                    editedTranscription = "編集された文字起こし",
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `削除済みメモの場合は例外を返す`() = runTest {
+        val userId = UUID.randomUUID()
+        val memoId = UUID.randomUUID()
+
+        // 削除済みメモを作成
+        val deletedMemo = VoiceMemo.create(
+            id = memoId,
+            userId = userId,
+            languageCode = "ja-JP",
+        )
+            .startTranscription()
+            .completeTranscription(text = "文字起こし", fallbackUsed = false)
+            .startFormatting()
+            .completeFormatting(
+                title = "タイトル",
+                content = "内容",
+                tags = emptyList(),
+                fallbackUsed = false,
+                folderId = null,
+            )
+            .markAsDeleted()
+
+        val voiceMemoRepository = FakeVoiceMemoRepository()
+        voiceMemoRepository.save(deletedMemo)
+
+        val folderRepository = FakeFolderRepository()
+        val useCase = ResummarizeUseCase(
+            voiceMemoRepository = voiceMemoRepository,
+            folderRepository = folderRepository,
+            folderPathResolver = FolderPathResolver(folderRepository),
+            memoFormatter = FakeMemoFormatter("", "", emptyList()),
+            executionTimer = FakeExecutionTimer(TestTimeSource(), emptyList()),
+        )
+
+        // 実行して例外を確認
+        assertThrowsSuspend<DomainException> {
+            useCase.execute(
+                ResummarizeInput(
+                    memoId = memoId,
+                    userId = userId,
+                    editedTranscription = "編集された文字起こし",
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `メモが存在しない場合は例外を返す`() = runTest {
+        val userId = UUID.randomUUID()
+        val memoId = UUID.randomUUID()
+
+        val voiceMemoRepository = FakeVoiceMemoRepository()
+        val folderRepository = FakeFolderRepository()
+        val useCase = ResummarizeUseCase(
+            voiceMemoRepository = voiceMemoRepository,
+            folderRepository = folderRepository,
+            folderPathResolver = FolderPathResolver(folderRepository),
+            memoFormatter = FakeMemoFormatter("", "", emptyList()),
+            executionTimer = FakeExecutionTimer(TestTimeSource(), emptyList()),
+        )
+
+        // 実行して例外を確認
+        assertThrowsSuspend<DomainException> {
+            useCase.execute(
+                ResummarizeInput(
+                    memoId = memoId,
+                    userId = userId,
+                    editedTranscription = "編集された文字起こし",
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `空の文字起こしテキストの場合は例外を返す`() = runTest {
+        val userId = UUID.randomUUID()
+        val memoId = UUID.randomUUID()
+
+        val existingMemo = VoiceMemo.create(
+            id = memoId,
+            userId = userId,
+            languageCode = "ja-JP",
+        )
+            .startTranscription()
+            .completeTranscription(text = "元の文字起こし", fallbackUsed = false)
+            .startFormatting()
+            .completeFormatting(
+                title = "タイトル",
+                content = "内容",
+                tags = emptyList(),
+                fallbackUsed = false,
+                folderId = null,
+            )
+
+        val voiceMemoRepository = FakeVoiceMemoRepository()
+        voiceMemoRepository.save(existingMemo)
+
+        val folderRepository = FakeFolderRepository()
+        val useCase = ResummarizeUseCase(
+            voiceMemoRepository = voiceMemoRepository,
+            folderRepository = folderRepository,
+            folderPathResolver = FolderPathResolver(folderRepository),
+            memoFormatter = FakeMemoFormatter("", "", emptyList()),
+            executionTimer = FakeExecutionTimer(TestTimeSource(), emptyList()),
+        )
+
+        // 実行して例外を確認
+        assertThrowsSuspend<IllegalArgumentException> {
+            useCase.execute(
+                ResummarizeInput(
+                    memoId = memoId,
+                    userId = userId,
+                    editedTranscription = "",
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `AI整形が失敗した場合はフォールバックを使用する`() = runTest {
+        val userId = UUID.randomUUID()
+        val memoId = UUID.randomUUID()
+
+        val existingMemo = VoiceMemo.create(
+            id = memoId,
+            userId = userId,
+            languageCode = "ja-JP",
+        )
+            .startTranscription()
+            .completeTranscription(text = "元の文字起こし", fallbackUsed = false)
+            .startFormatting()
+            .completeFormatting(
+                title = "元のタイトル",
+                content = "元の内容",
+                tags = listOf("old-tag"),
+                fallbackUsed = false,
+                folderId = null,
+            )
+
+        val voiceMemoRepository = FakeVoiceMemoRepository()
+        voiceMemoRepository.save(existingMemo)
+
+        val folderRepository = FakeFolderRepository()
+        val memoFormatter = FailingMemoFormatter()
+        val executionTimer = FakeExecutionTimer(TestTimeSource(), listOf(100.milliseconds))
+
+        val useCase = ResummarizeUseCase(
+            voiceMemoRepository = voiceMemoRepository,
+            folderRepository = folderRepository,
+            folderPathResolver = FolderPathResolver(folderRepository),
+            memoFormatter = memoFormatter,
+            executionTimer = executionTimer,
+        )
+
+        // 実行
+        val result = useCase.execute(
+            ResummarizeInput(
+                memoId = memoId,
+                userId = userId,
+                editedTranscription = "編集された文字起こし",
+            ),
+        )
+
+        // フォールバック結果を検証
+        assertEquals("ボイスメモ", result.voiceMemo.title)
+        assertEquals("編集された文字起こし", result.voiceMemo.content)
+        assertEquals(emptyList<String>(), result.voiceMemo.tags)
+        assertEquals("編集された文字起こし", result.voiceMemo.transcriptionText)
+        assertTrue(result.voiceMemo.formatting.fallbackUsed)
+    }
+
+    @Test
+    fun `フォルダーパスが指定された場合はフォルダーを作成する`() = runTest {
+        val userId = UUID.randomUUID()
+        val memoId = UUID.randomUUID()
+
+        val existingMemo = VoiceMemo.create(
+            id = memoId,
+            userId = userId,
+            languageCode = "ja-JP",
+        )
+            .startTranscription()
+            .completeTranscription(text = "元の文字起こし", fallbackUsed = false)
+            .startFormatting()
+            .completeFormatting(
+                title = "元のタイトル",
+                content = "元の内容",
+                tags = emptyList(),
+                fallbackUsed = false,
+                folderId = null,
+            )
+
+        val voiceMemoRepository = FakeVoiceMemoRepository()
+        voiceMemoRepository.save(existingMemo)
+
+        val folderRepository = FakeFolderRepository()
+        val memoFormatter = FakeMemoFormatter(
+            title = "新しいタイトル",
+            content = "新しい内容",
+            tags = emptyList(),
+            folderPath = "仕事/議事録",
+        )
+        val executionTimer = FakeExecutionTimer(TestTimeSource(), listOf(150.milliseconds))
+
+        val useCase = ResummarizeUseCase(
+            voiceMemoRepository = voiceMemoRepository,
+            folderRepository = folderRepository,
+            folderPathResolver = FolderPathResolver(folderRepository),
+            memoFormatter = memoFormatter,
+            executionTimer = executionTimer,
+        )
+
+        // 実行
+        val result = useCase.execute(
+            ResummarizeInput(
+                memoId = memoId,
+                userId = userId,
+                editedTranscription = "編集された文字起こし",
+            ),
+        )
+
+        // フォルダーが作成されたことを確認
+        assertNotNull(result.voiceMemo.formatting.folderId)
+        val createdFolders = folderRepository.savedFolders
+        assertTrue(createdFolders.size >= 2) // "仕事" と "議事録" の2つ
+
+        val workFolder = createdFolders.find { it.name == "仕事" && it.parentId == null }
+        assertNotNull(workFolder)
+
+        val meetingFolder = createdFolders.find { it.name == "議事録" && it.parentId == workFolder?.id }
+        assertNotNull(meetingFolder)
+
+        assertEquals(meetingFolder?.id, result.voiceMemo.formatting.folderId)
+    }
+
+    @Test
+    fun `既存フォルダーパスがAI整形に渡される`() = runTest {
+        val userId = UUID.randomUUID()
+        val memoId = UUID.randomUUID()
+
+        // 既存フォルダーを作成
+        val folderRepository = FakeFolderRepository()
+        val folder1 = Folder.create(
+            id = UUID.randomUUID(),
+            userId = userId,
+            name = "既存フォルダー1",
+            parentId = null,
+        )
+        val folder2 = Folder.create(
+            id = UUID.randomUUID(),
+            userId = userId,
+            name = "既存フォルダー2",
+            parentId = null,
+        )
+        folderRepository.save(folder1)
+        folderRepository.save(folder2)
+
+        val existingMemo = VoiceMemo.create(
+            id = memoId,
+            userId = userId,
+            languageCode = "ja-JP",
+        )
+            .startTranscription()
+            .completeTranscription(text = "元の文字起こし", fallbackUsed = false)
+            .startFormatting()
+            .completeFormatting(
+                title = "元のタイトル",
+                content = "元の内容",
+                tags = emptyList(),
+                fallbackUsed = false,
+                folderId = null,
+            )
+
+        val voiceMemoRepository = FakeVoiceMemoRepository()
+        voiceMemoRepository.save(existingMemo)
+
+        val memoFormatter = FakeMemoFormatter(
+            title = "新しいタイトル",
+            content = "新しい内容",
+            tags = emptyList(),
+            folderPath = null,
+        )
+        val executionTimer = FakeExecutionTimer(TestTimeSource(), listOf(150.milliseconds))
+
+        val useCase = ResummarizeUseCase(
+            voiceMemoRepository = voiceMemoRepository,
+            folderRepository = folderRepository,
+            folderPathResolver = FolderPathResolver(folderRepository),
+            memoFormatter = memoFormatter,
+            executionTimer = executionTimer,
+        )
+
+        // 実行
+        useCase.execute(
+            ResummarizeInput(
+                memoId = memoId,
+                userId = userId,
+                editedTranscription = "編集された文字起こし",
+            ),
+        )
+
+        // MemoFormatterに渡されたexistingFolderPathsを確認
+        assertNotNull(memoFormatter.receivedCommand)
+        val existingPaths = memoFormatter.receivedCommand?.existingFolderPaths ?: emptyList()
+        assertEquals(2, existingPaths.size)
+        assertTrue(existingPaths.contains("既存フォルダー1"))
+        assertTrue(existingPaths.contains("既存フォルダー2"))
+    }
+}
+
+/**
+ * 常に失敗するMemoFormatterモック（フォールバックテスト用）
+ */
+private class FailingMemoFormatter : MemoFormatter {
+    override suspend fun format(command: MemoFormatCommand): MemoFormatResult {
+        throw RuntimeException("AI formatting failed")
+    }
+}

--- a/src/test/kotlin/com/assari/voicebooklm/usecase/memo/ResummarizeUseCaseTest.kt
+++ b/src/test/kotlin/com/assari/voicebooklm/usecase/memo/ResummarizeUseCaseTest.kt
@@ -246,7 +246,7 @@ class ResummarizeUseCaseTest {
         )
 
         // 実行して例外を確認
-        assertThrowsSuspend<IllegalArgumentException> {
+        assertThrowsSuspend<DomainException> {
             useCase.execute(
                 ResummarizeInput(
                     memoId = memoId,


### PR DESCRIPTION
## 関連Issue
<!-- #の後ろに対応するissue番号を書く -->
Closes #28 

## やったこと
 以下のファイルを追加・変更しました:

  - ResummarizeUseCase.kt - メモ再要約のビジネスロジック（147行）
  - MemoController.kt - 再要約APIエンドポイント追加（59行）
  - MemoRequest.kt / MemoResponse.kt - リクエスト/レスポンスの型定義
  - MemoControllerTest.kt - テスト追加

## 動作確認
<!-- テスト内容など -->
- [ ] ビルドできた
- [ ] swaggerでテスト済

## 参考にした資料

