### PR TITLE
フォルダ一覧APIにメモ数を追加 #91

### DIFF
--- a/src/main/kotlin/com/assari/voicebooklm/domain/repository/VoiceMemoRepository.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/domain/repository/VoiceMemoRepository.kt
@@ -41,4 +41,17 @@ interface VoiceMemoRepository {
      * @return メモが存在する場合true
      */
     suspend fun existsByUserIdAndFolderId(userId: UUID, folderId: UUID): Boolean
+
+    /**
+     * 複数のフォルダー（子フォルダー含む）のメモ数をカウントする
+     *
+     * @param userId ユーザーID
+     * @param folderIdsWithDescendants フォルダーIDとその子孫フォルダーIDのマップ
+     *                                 キー: フォルダーID、値: そのフォルダーID + 子孫フォルダーIDのリスト
+     * @return フォルダーIDをキー、メモ数を値とするマップ
+     */
+    suspend fun countByFolderIds(
+        userId: UUID,
+        folderIdsWithDescendants: Map<UUID, List<UUID>>,
+    ): Map<UUID, Int>
 }

--- a/src/main/kotlin/com/assari/voicebooklm/infrastructure/postgres_jdbc/memo/MemoJdbcRepository.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/infrastructure/postgres_jdbc/memo/MemoJdbcRepository.kt
@@ -2,6 +2,7 @@ package com.assari.voicebooklm.infrastructure.postgres_jdbc.memo
 
 import org.springframework.data.jdbc.repository.query.Modifying
 import org.springframework.data.jdbc.repository.query.Query
+import org.springframework.data.relational.core.mapping.Column
 import org.springframework.data.repository.CrudRepository
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
@@ -73,4 +74,34 @@ interface MemoJdbcRepository : CrudRepository<MemoEntity, UUID> {
         @Param("userId") userId: UUID,
         @Param("folderId") folderId: UUID,
     ): Boolean
+
+    /**
+     * 複数のフォルダー（子フォルダー含む）のメモ数をカウントする
+     *
+     * @param userId ユーザーID
+     * @param folderIds カウント対象のフォルダーIDリスト（親フォルダーID + 子孫フォルダーIDを含む）
+     * @return フォルダーIDをキー、メモ数を値とするマップ（Row型）
+     */
+    @Query("""
+        SELECT folder_id, COUNT(*) as count
+        FROM memos
+        WHERE user_id = :userId 
+          AND folder_id IN (:folderIds)
+          AND deleted = false
+        GROUP BY folder_id
+    """)
+    fun countByFolderIds(
+        @Param("userId") userId: UUID,
+        @Param("folderIds") folderIds: List<UUID>,
+    ): List<FolderMemoCount>
 }
+
+/**
+ * フォルダーごとのメモ数（SQLクエリ結果用）
+ */
+data class FolderMemoCount(
+    @Column("folder_id")
+    val folderId: UUID,
+    @Column("count")
+    val count: Long,
+)

--- a/src/main/kotlin/com/assari/voicebooklm/infrastructure/postgres_jdbc/memo/VoiceMemoRepositoryImpl.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/infrastructure/postgres_jdbc/memo/VoiceMemoRepositoryImpl.kt
@@ -41,6 +41,27 @@ class VoiceMemoRepositoryImpl(
     override suspend fun existsByUserIdAndFolderId(userId: UUID, folderId: UUID): Boolean =
         memoJdbcRepository.existsByUserIdAndFolderId(userId, folderId)
 
+    override suspend fun countByFolderIds(
+        userId: UUID,
+        folderIdsWithDescendants: Map<UUID, List<UUID>>,
+    ): Map<UUID, Int> {
+        // すべてのフォルダーID（親 + 子孫）をフラット化
+        val allFolderIds = folderIdsWithDescendants.values.flatten().distinct()
+
+        if (allFolderIds.isEmpty()) {
+            return emptyMap()
+        }
+
+        // データベースからメモ数を取得
+        val counts = memoJdbcRepository.countByFolderIds(userId, allFolderIds)
+        val countMap = counts.associate { it.folderId to it.count.toInt() }
+
+        // 各フォルダーIDについて、そのフォルダーと子孫フォルダーのメモ数を合計
+        return folderIdsWithDescendants.mapValues { (_, descendantIds) ->
+            descendantIds.sumOf { folderId -> countMap[folderId] ?: 0 }
+        }
+    }
+
     /**
      * SQLワイルドカード文字（%、_）をエスケープする
      */

--- a/src/main/kotlin/com/assari/voicebooklm/presentation/controller/folder/FolderResponse.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/presentation/controller/folder/FolderResponse.kt
@@ -27,6 +27,7 @@ data class FolderResponse(
     val name: String,
     val parentId: UUID?,
     val path: String,
+    val memoCount: Int,
 ) {
     companion object {
         fun from(folderWithPath: FolderWithPath): FolderResponse {
@@ -35,6 +36,7 @@ data class FolderResponse(
                 name = folderWithPath.folder.name,
                 parentId = folderWithPath.folder.parentId,
                 path = folderWithPath.path,
+                memoCount = folderWithPath.memoCount,
             )
         }
 
@@ -44,6 +46,7 @@ data class FolderResponse(
                 name = folder.name,
                 parentId = folder.parentId,
                 path = path,
+                memoCount = 0, // 単一フォルダ取得時はメモ数は0（必要に応じて後で実装）
             )
         }
     }

--- a/src/main/kotlin/com/assari/voicebooklm/presentation/controller/folder/FolderResponse.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/presentation/controller/folder/FolderResponse.kt
@@ -46,7 +46,7 @@ data class FolderResponse(
                 name = folder.name,
                 parentId = folder.parentId,
                 path = path,
-                memoCount = 0, // 単一フォルダ取得時はメモ数は0（必要に応じて後で実装）
+                memoCount = 0, // フォルダー作成/更新APIではメモ数は返さない仕様のため常に0（一覧APIでは実装済み）
             )
         }
     }

--- a/src/main/kotlin/com/assari/voicebooklm/usecase/folder/ListFoldersUseCase.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/usecase/folder/ListFoldersUseCase.kt
@@ -3,6 +3,7 @@ package com.assari.voicebooklm.usecase.folder
 import com.assari.voicebooklm.domain.model.Folder
 import com.assari.voicebooklm.domain.model.buildPath
 import com.assari.voicebooklm.domain.repository.FolderRepository
+import com.assari.voicebooklm.domain.repository.VoiceMemoRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -13,17 +14,29 @@ import java.util.UUID
 @Service
 open class ListFoldersUseCase(
     private val folderRepository: FolderRepository,
+    private val voiceMemoRepository: VoiceMemoRepository,
 ) {
     @Transactional(readOnly = true)
     open suspend fun execute(input: ListFoldersInput): ListFoldersOutput {
         val folders = folderRepository.findByUserId(input.userId)
         val folderMap = folders.associateBy { it.id }
 
+        // 各フォルダーの子孫フォルダーIDを取得
+        val folderIdsWithDescendants = folders.associate { folder ->
+            val descendantIds = folderRepository.findDescendantIds(folder.id)
+            folder.id to (listOf(folder.id) + descendantIds)
+        }
+
+        // メモ数を一括取得
+        val memoCounts = voiceMemoRepository.countByFolderIds(input.userId, folderIdsWithDescendants)
+
         val foldersWithPath = folders.map { folder ->
             val path = folder.buildPath(folderMap)
+            val memoCount = memoCounts[folder.id] ?: 0
             FolderWithPath(
                 folder = folder,
                 path = path,
+                memoCount = memoCount,
             )
         }.sortedBy { it.path }
 
@@ -42,4 +55,5 @@ data class ListFoldersOutput(
 data class FolderWithPath(
     val folder: Folder,
     val path: String,
+    val memoCount: Int,
 )

--- a/src/test/kotlin/com/assari/voicebooklm/presentation/controller/folder/FolderControllerTest.kt
+++ b/src/test/kotlin/com/assari/voicebooklm/presentation/controller/folder/FolderControllerTest.kt
@@ -74,8 +74,8 @@ class FolderControllerTest {
         val input = ListFoldersInput(userId = userId)
         coEvery { listFoldersUseCase.execute(input) } returns ListFoldersOutput(
             folders = listOf(
-                FolderWithPath(folder = folder1, path = "仕事"),
-                FolderWithPath(folder = folder2, path = "プライベート"),
+                FolderWithPath(folder = folder1, path = "仕事", memoCount = 0),
+                FolderWithPath(folder = folder2, path = "プライベート", memoCount = 0),
             ),
         )
 
@@ -87,9 +87,11 @@ class FolderControllerTest {
         assertEquals(folder1.id, body.folders[0].id)
         assertEquals("仕事", body.folders[0].name)
         assertEquals("仕事", body.folders[0].path)
+        assertEquals(0, body.folders[0].memoCount) // メモ数が含まれる
         assertEquals(folder2.id, body.folders[1].id)
         assertEquals("プライベート", body.folders[1].name)
         assertEquals("プライベート", body.folders[1].path)
+        assertEquals(0, body.folders[1].memoCount) // メモ数が含まれる
     }
 
     @Test
@@ -110,8 +112,8 @@ class FolderControllerTest {
         val input = ListFoldersInput(userId = userId)
         coEvery { listFoldersUseCase.execute(input) } returns ListFoldersOutput(
             folders = listOf(
-                FolderWithPath(folder = parentFolder, path = "仕事"),
-                FolderWithPath(folder = childFolder, path = "仕事/プロジェクトA"),
+                FolderWithPath(folder = parentFolder, path = "仕事", memoCount = 0),
+                FolderWithPath(folder = childFolder, path = "仕事/プロジェクトA", memoCount = 0),
             ),
         )
 
@@ -121,8 +123,10 @@ class FolderControllerTest {
         val body = requireNotNull(response.body) { "response body should not be null" }
         assertEquals(2, body.folders.size)
         assertEquals("仕事", body.folders[0].path)
+        assertEquals(0, body.folders[0].memoCount) // メモ数が含まれる
         assertEquals("仕事/プロジェクトA", body.folders[1].path)
         assertEquals(parentFolder.id, body.folders[1].parentId)
+        assertEquals(0, body.folders[1].memoCount) // メモ数が含まれる
     }
 
     @Test
@@ -130,7 +134,7 @@ class FolderControllerTest {
         val userId = UUID.randomUUID()
         val input = ListFoldersInput(userId = userId)
         coEvery { listFoldersUseCase.execute(input) } returns ListFoldersOutput(
-            folders = emptyList(),
+            folders = emptyList()
         )
 
         val response = controller.listFolders(userId)
@@ -179,6 +183,7 @@ class FolderControllerTest {
         assertEquals("仕事", body.name)
         assertNull(body.parentId)
         assertEquals("仕事", body.path)
+        assertEquals(0, body.memoCount) // フォルダー作成時はメモ数0
     }
 
     @Test
@@ -210,6 +215,7 @@ class FolderControllerTest {
         assertEquals("プロジェクトA", body.name)
         assertEquals(parentId, body.parentId)
         assertEquals("仕事/プロジェクトA", body.path)
+        assertEquals(0, body.memoCount) // フォルダー作成時はメモ数0
     }
 
     @Test
@@ -294,6 +300,7 @@ class FolderControllerTest {
         assertEquals(folderId, body.id)
         assertEquals("Work", body.name)
         assertEquals("Work", body.path)
+        assertEquals(0, body.memoCount) // フォルダー更新時はメモ数0
     }
 
     @Test
@@ -327,6 +334,7 @@ class FolderControllerTest {
         assertEquals(folderId, body.id)
         assertEquals(newParentId, body.parentId)
         assertEquals("プライベート/プロジェクトA", body.path)
+        assertEquals(0, body.memoCount) // フォルダー更新時はメモ数0
     }
 
     @Test
@@ -359,6 +367,7 @@ class FolderControllerTest {
         assertEquals(folderId, body.id)
         assertNull(body.parentId)
         assertEquals("プロジェクトA", body.path)
+        assertEquals(0, body.memoCount) // フォルダー更新時はメモ数0
     }
 
     @Test
@@ -397,6 +406,7 @@ class FolderControllerTest {
         assertEquals("趣味プロジェクト", body.name)
         assertEquals(newParentId, body.parentId)
         assertEquals("プライベート/趣味プロジェクト", body.path)
+        assertEquals(0, body.memoCount) // フォルダー更新時はメモ数0
     }
 
     @Test

--- a/src/test/kotlin/com/assari/voicebooklm/usecase/folder/ListFoldersUseCaseTest.kt
+++ b/src/test/kotlin/com/assari/voicebooklm/usecase/folder/ListFoldersUseCaseTest.kt
@@ -1,6 +1,10 @@
 package com.assari.voicebooklm.usecase.folder
 
 import com.assari.voicebooklm.domain.model.Folder
+import com.assari.voicebooklm.domain.model.Formatting
+import com.assari.voicebooklm.domain.model.Transcription
+import com.assari.voicebooklm.domain.model.VoiceMemo
+import com.assari.voicebooklm.usecase.memo.InMemoryVoiceMemoRepository
 import java.util.UUID
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -30,17 +34,22 @@ class ListFoldersUseCaseTest {
         val folderRepository = InMemoryFolderRepository(
             initialFolders = listOf(folder1, folder2)
         )
-        val useCase = ListFoldersUseCase(folderRepository)
+        val voiceMemoRepository = InMemoryVoiceMemoRepository()
+        val useCase = ListFoldersUseCase(folderRepository, voiceMemoRepository)
 
         val result = useCase.execute(ListFoldersInput(userId = userId))
 
         assertEquals(2, result.folders.size)
+        // メモがない場合は0が返される
+        assertEquals(0, result.folders[0].memoCount)
+        assertEquals(0, result.folders[1].memoCount)
     }
 
     @Test
     fun `フォルダーが0件の場合は空の一覧を返す`() = runTest {
         val folderRepository = InMemoryFolderRepository()
-        val useCase = ListFoldersUseCase(folderRepository)
+        val voiceMemoRepository = InMemoryVoiceMemoRepository()
+        val useCase = ListFoldersUseCase(folderRepository, voiceMemoRepository)
 
         val result = useCase.execute(ListFoldersInput(userId = UUID.randomUUID()))
 
@@ -66,7 +75,8 @@ class ListFoldersUseCaseTest {
         val folderRepository = InMemoryFolderRepository(
             initialFolders = listOf(userFolder, otherUserFolder)
         )
-        val useCase = ListFoldersUseCase(folderRepository)
+        val voiceMemoRepository = InMemoryVoiceMemoRepository()
+        val useCase = ListFoldersUseCase(folderRepository, voiceMemoRepository)
 
         val result = useCase.execute(ListFoldersInput(userId = userId))
 
@@ -98,7 +108,8 @@ class ListFoldersUseCaseTest {
         val folderRepository = InMemoryFolderRepository(
             initialFolders = listOf(rootFolder, childFolder, grandchildFolder)
         )
-        val useCase = ListFoldersUseCase(folderRepository)
+        val voiceMemoRepository = InMemoryVoiceMemoRepository()
+        val useCase = ListFoldersUseCase(folderRepository, voiceMemoRepository)
 
         val result = useCase.execute(ListFoldersInput(userId = userId))
 
@@ -140,7 +151,8 @@ class ListFoldersUseCaseTest {
         val folderRepository = InMemoryFolderRepository(
             initialFolders = listOf(workFolder, privateFolder, workChild, privateChild)
         )
-        val useCase = ListFoldersUseCase(folderRepository)
+        val voiceMemoRepository = InMemoryVoiceMemoRepository()
+        val useCase = ListFoldersUseCase(folderRepository, voiceMemoRepository)
 
         val result = useCase.execute(ListFoldersInput(userId = userId))
 
@@ -151,5 +163,214 @@ class ListFoldersUseCaseTest {
         assertTrue(paths.contains("仕事/会議"))
         assertTrue(paths.contains("プライベート"))
         assertTrue(paths.contains("プライベート/旅行"))
+    }
+
+    @Test
+    fun `フォルダーにメモがある場合、メモ数が正しくカウントされる`() = runTest {
+        val userId = UUID.randomUUID()
+        val folder1 = Folder.create(
+            id = UUID.randomUUID(),
+            userId = userId,
+            name = "仕事",
+            parentId = null,
+        )
+        val folder2 = Folder.create(
+            id = UUID.randomUUID(),
+            userId = userId,
+            name = "プライベート",
+            parentId = null,
+        )
+        val memo1 = VoiceMemo.restore(
+            id = UUID.randomUUID(),
+            userId = userId,
+            transcription = Transcription.completed("テキスト1"),
+            formatting = Formatting.completed("タイトル1", "コンテンツ1", folderId = folder1.id),
+            deleted = false,
+            createdAt = java.time.Instant.now(),
+            updatedAt = java.time.Instant.now(),
+        )
+        val memo2 = VoiceMemo.restore(
+            id = UUID.randomUUID(),
+            userId = userId,
+            transcription = Transcription.completed("テキスト2"),
+            formatting = Formatting.completed("タイトル2", "コンテンツ2", folderId = folder1.id),
+            deleted = false,
+            createdAt = java.time.Instant.now(),
+            updatedAt = java.time.Instant.now(),
+        )
+        val memo3 = VoiceMemo.restore(
+            id = UUID.randomUUID(),
+            userId = userId,
+            transcription = Transcription.completed("テキスト3"),
+            formatting = Formatting.completed("タイトル3", "コンテンツ3", folderId = folder2.id),
+            deleted = false,
+            createdAt = java.time.Instant.now(),
+            updatedAt = java.time.Instant.now(),
+        )
+        val folderRepository = InMemoryFolderRepository(
+            initialFolders = listOf(folder1, folder2)
+        )
+        val voiceMemoRepository = InMemoryVoiceMemoRepository(
+            initialMemos = listOf(memo1, memo2, memo3)
+        )
+        val useCase = ListFoldersUseCase(folderRepository, voiceMemoRepository)
+
+        val result = useCase.execute(ListFoldersInput(userId = userId))
+
+        assertEquals(2, result.folders.size)
+        val folder1Result = result.folders.find { it.folder.id == folder1.id }
+        val folder2Result = result.folders.find { it.folder.id == folder2.id }
+        requireNotNull(folder1Result)
+        requireNotNull(folder2Result)
+        assertEquals(2, folder1Result.memoCount)
+        assertEquals(1, folder2Result.memoCount)
+    }
+
+    @Test
+    fun `子フォルダー内のメモも親フォルダーのメモ数に含まれる`() = runTest {
+        val userId = UUID.randomUUID()
+        val parentFolder = Folder.create(
+            id = UUID.randomUUID(),
+            userId = userId,
+            name = "仕事",
+            parentId = null,
+        )
+        val childFolder = Folder.create(
+            id = UUID.randomUUID(),
+            userId = userId,
+            name = "プロジェクトA",
+            parentId = parentFolder.id,
+        )
+        val parentMemo = VoiceMemo.restore(
+            id = UUID.randomUUID(),
+            userId = userId,
+            transcription = Transcription.completed("テキスト1"),
+            formatting = Formatting.completed("タイトル1", "コンテンツ1", folderId = parentFolder.id),
+            deleted = false,
+            createdAt = java.time.Instant.now(),
+            updatedAt = java.time.Instant.now(),
+        )
+        val childMemo1 = VoiceMemo.restore(
+            id = UUID.randomUUID(),
+            userId = userId,
+            transcription = Transcription.completed("テキスト2"),
+            formatting = Formatting.completed("タイトル2", "コンテンツ2", folderId = childFolder.id),
+            deleted = false,
+            createdAt = java.time.Instant.now(),
+            updatedAt = java.time.Instant.now(),
+        )
+        val childMemo2 = VoiceMemo.restore(
+            id = UUID.randomUUID(),
+            userId = userId,
+            transcription = Transcription.completed("テキスト3"),
+            formatting = Formatting.completed("タイトル3", "コンテンツ3", folderId = childFolder.id),
+            deleted = false,
+            createdAt = java.time.Instant.now(),
+            updatedAt = java.time.Instant.now(),
+        )
+        val folderRepository = InMemoryFolderRepository(
+            initialFolders = listOf(parentFolder, childFolder)
+        )
+        val voiceMemoRepository = InMemoryVoiceMemoRepository(
+            initialMemos = listOf(parentMemo, childMemo1, childMemo2)
+        )
+        val useCase = ListFoldersUseCase(folderRepository, voiceMemoRepository)
+
+        val result = useCase.execute(ListFoldersInput(userId = userId))
+
+        assertEquals(2, result.folders.size)
+        val parentResult = result.folders.find { it.folder.id == parentFolder.id }
+        val childResult = result.folders.find { it.folder.id == childFolder.id }
+        requireNotNull(parentResult)
+        requireNotNull(childResult)
+        // 親フォルダーには自分のメモ1件 + 子フォルダーのメモ2件 = 3件
+        assertEquals(3, parentResult.memoCount)
+        // 子フォルダーには自分のメモ2件
+        assertEquals(2, childResult.memoCount)
+    }
+
+    @Test
+    fun `削除済みメモはカウントに含まれない`() = runTest {
+        val userId = UUID.randomUUID()
+        val folder = Folder.create(
+            id = UUID.randomUUID(),
+            userId = userId,
+            name = "仕事",
+            parentId = null,
+        )
+        val activeMemo = VoiceMemo.restore(
+            id = UUID.randomUUID(),
+            userId = userId,
+            transcription = Transcription.completed("テキスト1"),
+            formatting = Formatting.completed("タイトル1", "コンテンツ1", folderId = folder.id),
+            deleted = false,
+            createdAt = java.time.Instant.now(),
+            updatedAt = java.time.Instant.now(),
+        )
+        val deletedMemo = VoiceMemo.restore(
+            id = UUID.randomUUID(),
+            userId = userId,
+            transcription = Transcription.completed("テキスト2"),
+            formatting = Formatting.completed("タイトル2", "コンテンツ2", folderId = folder.id),
+            deleted = true, // 削除済み
+            createdAt = java.time.Instant.now(),
+            updatedAt = java.time.Instant.now(),
+        )
+        val folderRepository = InMemoryFolderRepository(
+            initialFolders = listOf(folder)
+        )
+        val voiceMemoRepository = InMemoryVoiceMemoRepository(
+            initialMemos = listOf(activeMemo, deletedMemo)
+        )
+        val useCase = ListFoldersUseCase(folderRepository, voiceMemoRepository)
+
+        val result = useCase.execute(ListFoldersInput(userId = userId))
+
+        assertEquals(1, result.folders.size)
+        // 削除済みメモはカウントに含まれない
+        assertEquals(1, result.folders[0].memoCount)
+    }
+
+    @Test
+    fun `他ユーザーのメモはカウントに含まれない`() = runTest {
+        val userId = UUID.randomUUID()
+        val otherUserId = UUID.randomUUID()
+        val folder = Folder.create(
+            id = UUID.randomUUID(),
+            userId = userId,
+            name = "仕事",
+            parentId = null,
+        )
+        val userMemo = VoiceMemo.restore(
+            id = UUID.randomUUID(),
+            userId = userId,
+            transcription = Transcription.completed("テキスト1"),
+            formatting = Formatting.completed("タイトル1", "コンテンツ1", folderId = folder.id),
+            deleted = false,
+            createdAt = java.time.Instant.now(),
+            updatedAt = java.time.Instant.now(),
+        )
+        val otherUserMemo = VoiceMemo.restore(
+            id = UUID.randomUUID(),
+            userId = otherUserId, // 他ユーザー
+            transcription = Transcription.completed("テキスト2"),
+            formatting = Formatting.completed("タイトル2", "コンテンツ2", folderId = folder.id),
+            deleted = false,
+            createdAt = java.time.Instant.now(),
+            updatedAt = java.time.Instant.now(),
+        )
+        val folderRepository = InMemoryFolderRepository(
+            initialFolders = listOf(folder)
+        )
+        val voiceMemoRepository = InMemoryVoiceMemoRepository(
+            initialMemos = listOf(userMemo, otherUserMemo)
+        )
+        val useCase = ListFoldersUseCase(folderRepository, voiceMemoRepository)
+
+        val result = useCase.execute(ListFoldersInput(userId = userId))
+
+        assertEquals(1, result.folders.size)
+        // 他ユーザーのメモはカウントに含まれない
+        assertEquals(1, result.folders[0].memoCount)
     }
 }

--- a/src/test/kotlin/com/assari/voicebooklm/usecase/memo/CreateMemoUseCaseTest.kt
+++ b/src/test/kotlin/com/assari/voicebooklm/usecase/memo/CreateMemoUseCaseTest.kt
@@ -216,6 +216,21 @@ internal class FakeVoiceMemoRepository : VoiceMemoRepository {
 
     override suspend fun existsByUserIdAndFolderId(userId: UUID, folderId: UUID): Boolean =
         savedMemos.any { it.userId == userId && it.formatting.folderId == folderId && !it.deleted }
+
+    override suspend fun countByFolderIds(
+        userId: UUID,
+        folderIdsWithDescendants: Map<UUID, List<UUID>>,
+    ): Map<UUID, Int> {
+        // ユーザーの削除されていないメモをフィルタ
+        val userMemos = savedMemos.filter { it.userId == userId && !it.deleted }
+
+        // 各フォルダーIDについて、そのフォルダーと子孫フォルダーに属するメモをカウント
+        return folderIdsWithDescendants.mapValues { (_, descendantIds) ->
+            userMemos.count { memo ->
+                memo.formatting.folderId != null && memo.formatting.folderId in descendantIds
+            }
+        }
+    }
 }
 
 internal class FakeFolderRepository : FolderRepository {

--- a/src/test/kotlin/com/assari/voicebooklm/usecase/memo/InMemoryVoiceMemoRepository.kt
+++ b/src/test/kotlin/com/assari/voicebooklm/usecase/memo/InMemoryVoiceMemoRepository.kt
@@ -43,6 +43,21 @@ internal class InMemoryVoiceMemoRepository(
     override suspend fun existsByUserIdAndFolderId(userId: UUID, folderId: UUID): Boolean =
         memos.any { it.userId == userId && it.formatting.folderId == folderId && !it.deleted }
 
+    override suspend fun countByFolderIds(
+        userId: UUID,
+        folderIdsWithDescendants: Map<UUID, List<UUID>>,
+    ): Map<UUID, Int> {
+        // ユーザーの削除されていないメモをフィルタ
+        val userMemos = memos.filter { it.userId == userId && !it.deleted }
+
+        // 各フォルダーIDについて、そのフォルダーと子孫フォルダーに属するメモをカウント
+        return folderIdsWithDescendants.mapValues { (_, descendantIds) ->
+            userMemos.count { memo ->
+                memo.formatting.folderId != null && memo.formatting.folderId in descendantIds
+            }
+        }
+    }
+
     /**
      * テスト用：削除済みメモも含めて取得するメソッド
      */


### PR DESCRIPTION
- FolderResponseにmemoCountフィールドを追加
- ListFoldersUseCaseで各フォルダのメモ数を取得
- VoiceMemoRepositoryにcountByFolderIdsメソッドを追加
- 子フォルダ内のメモも含めて再帰的にカウント

## 関連Issue
<!-- #の後ろに対応するissue番号を書く -->
Closes #91 

## やったこと

## 動作確認
- [x] swaggerでメモカウントの表示を確認
- [x] memocountとメモの数が同じことを確認 
## 参考にした資料

