### PR TITLE
タグ検索機能追加 #85

### DIFF
--- a/src/main/kotlin/com/assari/voicebooklm/presentation/controller/memo/MemoController.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/presentation/controller/memo/MemoController.kt
@@ -79,6 +79,8 @@ class MemoController(
         @RequestParam(required = false, defaultValue = "false") uncategorizedOnly: Boolean,
         @Parameter(description = "キーワード検索（タイトルまたはコンテントに含まれるメモを検索）")
         @RequestParam(required = false) keyword: String?,
+        @Parameter(description = "タグでフィルタリング（AND検索: 指定されたすべてのタグを持つメモを取得）")
+        @RequestParam(required = false) tags: List<String>?,
         @Parameter(description = "ソート項目（updated_at, created_at, title）")
         @RequestParam(required = false, defaultValue = "updated_at") sort: String,
         @Parameter(description = "ソート順序（asc, desc）")
@@ -125,6 +127,7 @@ class MemoController(
                 includeDescendants = includeDescendants,
                 uncategorizedOnly = uncategorizedOnly,
                 keyword = keyword,
+                tags = tags,
                 sortBy = sortBy,
                 sortOrder = sortOrder,
                 limit = limit,

--- a/src/main/kotlin/com/assari/voicebooklm/usecase/memo/ListMemosUseCase.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/usecase/memo/ListMemosUseCase.kt
@@ -46,6 +46,17 @@ open class ListMemosUseCase(
             else -> memos
         }
 
+        // 2.5. タグフィルタリング（AND検索: 指定されたすべてのタグを持つメモのみ）
+        if (!input.tags.isNullOrEmpty()) {
+            val requiredTags = input.tags.map { it.trim().lowercase() }.filter { it.isNotEmpty() }.toSet()
+            if (requiredTags.isNotEmpty()) {
+                memos = memos.filter { memo ->
+                    val memoTags = memo.formatting.tags.map { it.lowercase() }.toSet()
+                    requiredTags.all { requiredTag -> memoTags.contains(requiredTag) }
+                }
+            }
+        }
+
         // 3. フォルダー情報を取得
         val folders = folderRepository.findByUserId(input.userId)
         val folderMap = folders.associateBy { it.id }
@@ -113,6 +124,8 @@ data class ListMemosInput(
     val uncategorizedOnly: Boolean = false,
     /** キーワード検索（null または空の場合は全件） */
     val keyword: String? = null,
+    /** タグでフィルタリング（AND検索: すべてのタグを持つメモのみ取得） */
+    val tags: List<String>? = null,
     /** ソート項目（デフォルト: updated_at） */
     val sortBy: MemoSortField = MemoSortField.UPDATED_AT,
     /** ソート順序（デフォルト: desc） */

--- a/src/test/kotlin/com/assari/voicebooklm/presentation/controller/memo/MemoControllerTest.kt
+++ b/src/test/kotlin/com/assari/voicebooklm/presentation/controller/memo/MemoControllerTest.kt
@@ -92,7 +92,7 @@ class MemoControllerTest {
             hasMore = false,
         )
 
-        val response = controller.listMemos(userId, null, false, false, null, "updated_at", "desc", null, null)
+        val response = controller.listMemos(userId, null, false, false, null, null, "updated_at", "desc", null, null)
 
         assertEquals(HttpStatus.OK, response.statusCode)
         val body = requireNotNull(response.body) { "response body should not be null" }
@@ -121,7 +121,7 @@ class MemoControllerTest {
             hasMore = false,
         )
 
-        val response = controller.listMemos(userId, null, false, false, null, "updated_at", "desc", null, null)
+        val response = controller.listMemos(userId, null, false, false, null, null, "updated_at", "desc", null, null)
 
         assertEquals(HttpStatus.OK, response.statusCode)
         val body = requireNotNull(response.body) { "response body should not be null" }
@@ -131,7 +131,7 @@ class MemoControllerTest {
     @Test
     fun `listMemos 未認証の場合はResponseStatusExceptionがスローされる`() = runBlocking {
         val exception = assertThrows<ResponseStatusException> {
-            controller.listMemos(null, null, false, false, null, "updated_at", "desc", null, null)
+            controller.listMemos(null, null, false, false, null, null, "updated_at", "desc", null, null)
         }
 
         assertEquals(HttpStatus.UNAUTHORIZED, exception.statusCode)
@@ -141,7 +141,7 @@ class MemoControllerTest {
     fun `listMemos limitが0の場合はBAD_REQUESTがスローされる`() = runBlocking {
         val userId = UUID.randomUUID()
         val exception = assertThrows<ResponseStatusException> {
-            controller.listMemos(userId, null, false, false, null, "updated_at", "desc", 0, null)
+            controller.listMemos(userId, null, false, false, null, null, "updated_at", "desc", 0, null)
         }
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.statusCode)
@@ -152,7 +152,7 @@ class MemoControllerTest {
     fun `listMemos limitが負の値の場合はBAD_REQUESTがスローされる`() = runBlocking {
         val userId = UUID.randomUUID()
         val exception = assertThrows<ResponseStatusException> {
-            controller.listMemos(userId, null, false, false, null, "updated_at", "desc", -1, null)
+            controller.listMemos(userId, null, false, false, null, null, "updated_at", "desc", -1, null)
         }
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.statusCode)
@@ -163,7 +163,7 @@ class MemoControllerTest {
     fun `listMemos offsetが負の値の場合はBAD_REQUESTがスローされる`() = runBlocking {
         val userId = UUID.randomUUID()
         val exception = assertThrows<ResponseStatusException> {
-            controller.listMemos(userId, null, false, false, null, "updated_at", "desc", null, -1)
+            controller.listMemos(userId, null, false, false, null, null, "updated_at", "desc", null, -1)
         }
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.statusCode)
@@ -194,7 +194,7 @@ class MemoControllerTest {
             hasMore = true,
         )
 
-        val response = controller.listMemos(userId, null, false, false, null, "updated_at", "desc", null, null)
+        val response = controller.listMemos(userId, null, false, false, null, null, "updated_at", "desc", null, null)
 
         assertEquals(HttpStatus.OK, response.statusCode)
         val body = requireNotNull(response.body) { "response body should not be null" }

--- a/src/test/kotlin/com/assari/voicebooklm/usecase/memo/ListMemosUseCaseTest.kt
+++ b/src/test/kotlin/com/assari/voicebooklm/usecase/memo/ListMemosUseCaseTest.kt
@@ -500,6 +500,153 @@ class ListMemosUseCaseTest {
         assertEquals(memo1.id, result.memos[0].memo.id)
     }
 
+    @Test
+    fun `単一タグでフィルタリングできる`() = runTest {
+        val userId = UUID.randomUUID()
+        val memo1 = VoiceMemo.create(id = UUID.randomUUID(), userId = userId)
+            .completeTranscription("text1")
+            .completeFormatting(title = "title1", content = "content1", tags = listOf("開発", "Kotlin"))
+        val memo2 = VoiceMemo.create(id = UUID.randomUUID(), userId = userId)
+            .completeTranscription("text2")
+            .completeFormatting(title = "title2", content = "content2", tags = listOf("開発", "Java"))
+        val memo3 = VoiceMemo.create(id = UUID.randomUUID(), userId = userId)
+            .completeTranscription("text3")
+            .completeFormatting(title = "title3", content = "content3", tags = listOf("ミーティング"))
+
+        val voiceMemoRepository = InMemoryVoiceMemoRepository(
+            initialMemos = listOf(memo1, memo2, memo3),
+        )
+        val folderRepository = InMemoryFolderRepository()
+        val useCase = ListMemosUseCase(voiceMemoRepository, folderRepository)
+
+        val result = useCase.execute(
+            ListMemosInput(
+                userId = userId,
+                tags = listOf("開発"),
+            )
+        )
+
+        assertEquals(2, result.memos.size)
+        val memoIds = result.memos.map { it.memo.id }
+        assertTrue(memoIds.contains(memo1.id))
+        assertTrue(memoIds.contains(memo2.id))
+    }
+
+    @Test
+    fun `複数タグでAND検索できる`() = runTest {
+        val userId = UUID.randomUUID()
+        val memo1 = VoiceMemo.create(id = UUID.randomUUID(), userId = userId)
+            .completeTranscription("text1")
+            .completeFormatting(title = "title1", content = "content1", tags = listOf("開発", "Kotlin"))
+        val memo2 = VoiceMemo.create(id = UUID.randomUUID(), userId = userId)
+            .completeTranscription("text2")
+            .completeFormatting(title = "title2", content = "content2", tags = listOf("開発", "Java"))
+        val memo3 = VoiceMemo.create(id = UUID.randomUUID(), userId = userId)
+            .completeTranscription("text3")
+            .completeFormatting(title = "title3", content = "content3", tags = listOf("開発", "Kotlin", "重要"))
+
+        val voiceMemoRepository = InMemoryVoiceMemoRepository(
+            initialMemos = listOf(memo1, memo2, memo3),
+        )
+        val folderRepository = InMemoryFolderRepository()
+        val useCase = ListMemosUseCase(voiceMemoRepository, folderRepository)
+
+        // 「開発」と「Kotlin」の両方を持つメモのみ取得
+        val result = useCase.execute(
+            ListMemosInput(
+                userId = userId,
+                tags = listOf("開発", "Kotlin"),
+            )
+        )
+
+        assertEquals(2, result.memos.size)
+        val memoIds = result.memos.map { it.memo.id }
+        assertTrue(memoIds.contains(memo1.id))
+        assertTrue(memoIds.contains(memo3.id))
+    }
+
+    @Test
+    fun `タグ検索とキーワード検索を組み合わせできる`() = runTest {
+        val userId = UUID.randomUUID()
+        val memo1 = VoiceMemo.create(id = UUID.randomUUID(), userId = userId)
+            .completeTranscription("text1")
+            .completeFormatting(title = "Kotlin開発入門", content = "content1", tags = listOf("開発"))
+        val memo2 = VoiceMemo.create(id = UUID.randomUUID(), userId = userId)
+            .completeTranscription("text2")
+            .completeFormatting(title = "Java開発入門", content = "content2", tags = listOf("開発"))
+        val memo3 = VoiceMemo.create(id = UUID.randomUUID(), userId = userId)
+            .completeTranscription("text3")
+            .completeFormatting(title = "Kotlinの基礎", content = "content3", tags = listOf("学習"))
+
+        val voiceMemoRepository = InMemoryVoiceMemoRepository(
+            initialMemos = listOf(memo1, memo2, memo3),
+        )
+        val folderRepository = InMemoryFolderRepository()
+        val useCase = ListMemosUseCase(voiceMemoRepository, folderRepository)
+
+        // 「開発」タグを持ち、かつタイトルに「Kotlin」を含むメモのみ取得
+        val result = useCase.execute(
+            ListMemosInput(
+                userId = userId,
+                keyword = "Kotlin",
+                tags = listOf("開発"),
+            )
+        )
+
+        assertEquals(1, result.memos.size)
+        assertEquals(memo1.id, result.memos[0].memo.id)
+    }
+
+    @Test
+    fun `タグ検索で大文字小文字を区別しない`() = runTest {
+        val userId = UUID.randomUUID()
+        val memo1 = VoiceMemo.create(id = UUID.randomUUID(), userId = userId)
+            .completeTranscription("text1")
+            .completeFormatting(title = "title1", content = "content1", tags = listOf("Development"))
+        val memo2 = VoiceMemo.create(id = UUID.randomUUID(), userId = userId)
+            .completeTranscription("text2")
+            .completeFormatting(title = "title2", content = "content2", tags = listOf("DEVELOPMENT"))
+
+        val voiceMemoRepository = InMemoryVoiceMemoRepository(
+            initialMemos = listOf(memo1, memo2),
+        )
+        val folderRepository = InMemoryFolderRepository()
+        val useCase = ListMemosUseCase(voiceMemoRepository, folderRepository)
+
+        // 小文字で検索しても大文字・小文字のタグがマッチする
+        val result = useCase.execute(
+            ListMemosInput(
+                userId = userId,
+                tags = listOf("development"),
+            )
+        )
+
+        assertEquals(2, result.memos.size)
+    }
+
+    @Test
+    fun `該当するタグがない場合は空の一覧を返す`() = runTest {
+        val userId = UUID.randomUUID()
+        val memo1 = VoiceMemo.create(id = UUID.randomUUID(), userId = userId)
+            .completeTranscription("text1")
+            .completeFormatting(title = "title1", content = "content1", tags = listOf("開発"))
+
+        val voiceMemoRepository = InMemoryVoiceMemoRepository(
+            initialMemos = listOf(memo1),
+        )
+        val folderRepository = InMemoryFolderRepository()
+        val useCase = ListMemosUseCase(voiceMemoRepository, folderRepository)
+
+        val result = useCase.execute(
+            ListMemosInput(
+                userId = userId,
+                tags = listOf("存在しないタグ"),
+            )
+        )
+
+        assertTrue(result.memos.isEmpty())
+    }
+
     // インメモリで動作する FolderRepository のテストダブル。
     private class InMemoryFolderRepository(
         initialFolders: List<Folder> = emptyList(),


### PR DESCRIPTION
- キーワードやタグ同士でand検索可能or検索は実装しない
- 小文字大文字区別なし
- 該当するタグがない場合は空の一覧

## 関連Issue
<!-- #の後ろに対応するissue番号を書く -->
Closes #85 

## やったこと

## 動作確認
<!-- テスト内容など -->
- [ ] ビルドできた

## 参考にした資料

