### PR TITLE
メモ詳細取得APIにフォルダー情報を追加 #92

### DIFF
--- a/src/main/kotlin/com/assari/voicebooklm/presentation/controller/memo/MemoResponse.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/presentation/controller/memo/MemoResponse.kt
@@ -88,12 +88,20 @@ data class MemoDetailResponse(
     val transcriptionText: String?,
     val transcriptionStatus: String,
     val formattingStatus: String,
+    val folder: FolderInfo?,
     val createdAt: Instant,
     val updatedAt: Instant,
 ) {
     companion object {
         fun from(result: GetMemoOutput): MemoDetailResponse {
             val memo = result.memo
+            val folderInfo = result.folder?.let { folder ->
+                FolderInfo(
+                    id = folder.id,
+                    name = folder.name,
+                    path = result.folderPath ?: folder.name,
+                )
+            }
             return MemoDetailResponse(
                 memoId = memo.id,
                 title = memo.title,
@@ -102,6 +110,7 @@ data class MemoDetailResponse(
                 transcriptionText = memo.transcriptionText,
                 transcriptionStatus = memo.transcription.status.name,
                 formattingStatus = memo.formatting.status.name,
+                folder = folderInfo,
                 createdAt = memo.createdAt,
                 updatedAt = memo.updatedAt,
             )
@@ -117,6 +126,7 @@ data class MemoDetailResponse(
                 transcriptionText = memo.transcriptionText,
                 transcriptionStatus = memo.transcription.status.name,
                 formattingStatus = memo.formatting.status.name,
+                folder = null, // UpdateMemoOutput にはフォルダー情報が含まれていないため null
                 createdAt = memo.createdAt,
                 updatedAt = memo.updatedAt,
             )
@@ -132,6 +142,7 @@ data class MemoDetailResponse(
                 transcriptionText = memo.transcriptionText,
                 transcriptionStatus = memo.transcription.status.name,
                 formattingStatus = memo.formatting.status.name,
+                folder = null, // ResummarizeOutput にはフォルダー情報が含まれていないため null
                 createdAt = memo.createdAt,
                 updatedAt = memo.updatedAt,
             )

--- a/src/main/kotlin/com/assari/voicebooklm/usecase/memo/GetMemoUseCase.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/usecase/memo/GetMemoUseCase.kt
@@ -42,16 +42,21 @@ open class GetMemoUseCase(
             throw DomainException(ErrorCode.MEMO_NOT_FOUND)
         }
 
-        // 3. フォルダー情報を取得
+        // 3. メモにフォルダーが紐づいていない場合は、フォルダー情報を取得せずに返却
+        if (memo.formatting.folderId == null) {
+            return GetMemoOutput(memo, null, null)
+        }
+
+        // 4. フォルダー情報を取得
         val folders = folderRepository.findByUserId(input.userId)
         val folderMap = folders.associateBy { it.id }
         val folderPathMap = folders.associate { it.id to it.buildPath(folderMap) }
 
-        // 4. メモに紐づくフォルダー情報を取得
+        // 5. メモに紐づくフォルダー情報を取得
         val folder = memo.formatting.folderId?.let { folderMap[it] }
         val folderPath = memo.formatting.folderId?.let { folderPathMap[it] }
 
-        // 5. 結果を返却
+        // 6. 結果を返却
         return GetMemoOutput(memo, folder, folderPath)
     }
 }

--- a/src/main/kotlin/com/assari/voicebooklm/usecase/memo/GetMemoUseCase.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/usecase/memo/GetMemoUseCase.kt
@@ -2,7 +2,10 @@ package com.assari.voicebooklm.usecase.memo
 
 import com.assari.voicebooklm.domain.exception.DomainException
 import com.assari.voicebooklm.domain.exception.ErrorCode
+import com.assari.voicebooklm.domain.model.Folder
 import com.assari.voicebooklm.domain.model.VoiceMemo
+import com.assari.voicebooklm.domain.model.buildPath
+import com.assari.voicebooklm.domain.repository.FolderRepository
 import com.assari.voicebooklm.domain.repository.VoiceMemoRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -18,6 +21,7 @@ import java.util.UUID
 @Service
 open class GetMemoUseCase(
     private val voiceMemoRepository: VoiceMemoRepository,
+    private val folderRepository: FolderRepository,
 ) {
     /**
      * メモを取得する
@@ -38,8 +42,17 @@ open class GetMemoUseCase(
             throw DomainException(ErrorCode.MEMO_NOT_FOUND)
         }
 
-        // 3. 結果を返却
-        return GetMemoOutput(memo)
+        // 3. フォルダー情報を取得
+        val folders = folderRepository.findByUserId(input.userId)
+        val folderMap = folders.associateBy { it.id }
+        val folderPathMap = folders.associate { it.id to it.buildPath(folderMap) }
+
+        // 4. メモに紐づくフォルダー情報を取得
+        val folder = memo.formatting.folderId?.let { folderMap[it] }
+        val folderPath = memo.formatting.folderId?.let { folderPathMap[it] }
+
+        // 5. 結果を返却
+        return GetMemoOutput(memo, folder, folderPath)
     }
 }
 
@@ -56,4 +69,6 @@ data class GetMemoInput(
  */
 data class GetMemoOutput(
     val memo: VoiceMemo,
+    val folder: Folder?,
+    val folderPath: String?,
 )

--- a/src/test/kotlin/com/assari/voicebooklm/presentation/controller/memo/MemoControllerTest.kt
+++ b/src/test/kotlin/com/assari/voicebooklm/presentation/controller/memo/MemoControllerTest.kt
@@ -217,7 +217,7 @@ class MemoControllerTest {
                 tags = listOf("tag1", "tag2"),
             )
 
-        coEvery { getMemoUseCase.execute(GetMemoInput(memoId, userId)) } returns GetMemoOutput(memo)
+        coEvery { getMemoUseCase.execute(GetMemoInput(memoId, userId)) } returns GetMemoOutput(memo, null, null)
 
         val response = controller.getMemo(memoId, userId)
 
@@ -238,7 +238,7 @@ class MemoControllerTest {
         val memoId = UUID.randomUUID()
         val memo = VoiceMemo.create(id = memoId, userId = userId)
 
-        coEvery { getMemoUseCase.execute(GetMemoInput(memoId, userId)) } returns GetMemoOutput(memo)
+        coEvery { getMemoUseCase.execute(GetMemoInput(memoId, userId)) } returns GetMemoOutput(memo, null, null)
 
         val response = controller.getMemo(memoId, userId)
 

--- a/src/test/kotlin/com/assari/voicebooklm/usecase/memo/GetMemoUseCaseTest.kt
+++ b/src/test/kotlin/com/assari/voicebooklm/usecase/memo/GetMemoUseCaseTest.kt
@@ -4,7 +4,7 @@ import com.assari.voicebooklm.domain.exception.DomainException
 import com.assari.voicebooklm.domain.exception.ErrorCode
 import com.assari.voicebooklm.domain.model.Folder
 import com.assari.voicebooklm.domain.model.VoiceMemo
-import com.assari.voicebooklm.domain.repository.FolderRepository
+import com.assari.voicebooklm.usecase.folder.InMemoryFolderRepository
 import java.util.UUID
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -185,48 +185,38 @@ class GetMemoUseCaseTest {
         assertEquals("仕事/プロジェクトA", result.folderPath)
     }
 
-    // インメモリで動作する FolderRepository のテストダブル
-    private class InMemoryFolderRepository(
-        initialFolders: List<Folder> = emptyList(),
-    ) : FolderRepository {
-        private val folders = initialFolders.toMutableList()
+    @Test
+    fun `削除されたフォルダーに紐づくメモを取得するとfolderとfolderPathがnullになる`() = runTest {
+        val userId = UUID.randomUUID()
+        val memoId = UUID.randomUUID()
+        val deletedFolderId = UUID.randomUUID()
 
-        override suspend fun save(folder: Folder): Folder {
-            folders.removeIf { it.id == folder.id }
-            folders += folder
-            return folder
-        }
+        // フォルダーに紐づくメモを作成（フォルダーは既に削除されている）
+        val memo = VoiceMemo.create(id = memoId, userId = userId)
+            .completeFormatting(
+                title = "テストメモ",
+                content = "コンテンツ",
+                tags = emptyList(),
+                folderId = deletedFolderId,
+            )
 
-        override suspend fun findById(id: UUID): Folder? = folders.find { it.id == id }
+        val voiceMemoRepository = InMemoryVoiceMemoRepository(
+            initialMemos = listOf(memo),
+        )
+        // フォルダーは存在しない（削除済み）ため、空のリポジトリを使用
+        val folderRepository = InMemoryFolderRepository(
+            initialFolders = emptyList(),
+        )
+        val useCase = GetMemoUseCase(voiceMemoRepository, folderRepository)
 
-        override suspend fun findByUserId(userId: UUID): List<Folder> = folders.filter { it.userId == userId }
+        val result = useCase.execute(GetMemoInput(memoId = memoId, userId = userId))
 
-        override suspend fun findByUserIdAndParentId(userId: UUID, parentId: UUID?): List<Folder> =
-            folders.filter { it.userId == userId && it.parentId == parentId }
+        // メモ情報を確認
+        assertEquals(memoId, result.memo.id)
+        assertEquals(userId, result.memo.userId)
 
-        override suspend fun findByUserIdAndPath(userId: UUID, path: String): Folder? = null
-
-        override suspend fun findDescendantIds(folderId: UUID): List<UUID> = emptyList()
-
-        override suspend fun delete(id: UUID) {
-            folders.removeIf { it.id == id }
-        }
-
-        override suspend fun existsByUserIdAndParentIdAndName(
-            userId: UUID,
-            parentId: UUID?,
-            name: String,
-            excludeId: UUID?,
-        ): Boolean =
-            folders.any {
-                it.userId == userId &&
-                        it.parentId == parentId &&
-                        it.name == name &&
-                        (excludeId == null || it.id != excludeId)
-            }
-
-        override fun deleteByUserId(userId: UUID) {
-            folders.removeIf { it.userId == userId }
-        }
+        // フォルダー情報はnull（フォルダーが存在しないため）
+        assertNull(result.folder)
+        assertNull(result.folderPath)
     }
 }

--- a/src/test/kotlin/com/assari/voicebooklm/usecase/memo/GetMemoUseCaseTest.kt
+++ b/src/test/kotlin/com/assari/voicebooklm/usecase/memo/GetMemoUseCaseTest.kt
@@ -2,10 +2,14 @@ package com.assari.voicebooklm.usecase.memo
 
 import com.assari.voicebooklm.domain.exception.DomainException
 import com.assari.voicebooklm.domain.exception.ErrorCode
+import com.assari.voicebooklm.domain.model.Folder
 import com.assari.voicebooklm.domain.model.VoiceMemo
+import com.assari.voicebooklm.domain.repository.FolderRepository
 import java.util.UUID
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
@@ -23,13 +27,17 @@ class GetMemoUseCaseTest {
         val voiceMemoRepository = InMemoryVoiceMemoRepository(
             initialMemos = listOf(memo),
         )
-        val useCase = GetMemoUseCase(voiceMemoRepository)
+        val folderRepository = InMemoryFolderRepository()
+        val useCase = GetMemoUseCase(voiceMemoRepository, folderRepository)
 
         val result = useCase.execute(GetMemoInput(memoId = memoId, userId = userId))
 
         // 取得したメモが正しいことを確認
         assertEquals(memoId, result.memo.id)
         assertEquals(userId, result.memo.userId)
+        // フォルダー情報は null
+        assertNull(result.folder)
+        assertNull(result.folderPath)
     }
 
     @Test
@@ -42,7 +50,8 @@ class GetMemoUseCaseTest {
         val voiceMemoRepository = InMemoryVoiceMemoRepository(
             initialMemos = listOf(memo),
         )
-        val useCase = GetMemoUseCase(voiceMemoRepository)
+        val folderRepository = InMemoryFolderRepository()
+        val useCase = GetMemoUseCase(voiceMemoRepository, folderRepository)
 
         val exception = assertThrows<DomainException> {
             useCase.execute(GetMemoInput(memoId = memoId, userId = otherUserId))
@@ -58,7 +67,8 @@ class GetMemoUseCaseTest {
         val nonExistentMemoId = UUID.randomUUID()
 
         val voiceMemoRepository = InMemoryVoiceMemoRepository()
-        val useCase = GetMemoUseCase(voiceMemoRepository)
+        val folderRepository = InMemoryFolderRepository()
+        val useCase = GetMemoUseCase(voiceMemoRepository, folderRepository)
 
         val exception = assertThrows<DomainException> {
             useCase.execute(GetMemoInput(memoId = nonExistentMemoId, userId = userId))
@@ -76,12 +86,147 @@ class GetMemoUseCaseTest {
         val voiceMemoRepository = InMemoryVoiceMemoRepository(
             initialMemos = listOf(memo),
         )
-        val useCase = GetMemoUseCase(voiceMemoRepository)
+        val folderRepository = InMemoryFolderRepository()
+        val useCase = GetMemoUseCase(voiceMemoRepository, folderRepository)
 
         val exception = assertThrows<DomainException> {
             useCase.execute(GetMemoInput(memoId = memoId, userId = userId))
         }
 
         assertEquals(ErrorCode.MEMO_NOT_FOUND, exception.code)
+    }
+
+    @Test
+    fun `フォルダーに紐づくメモを取得するとフォルダー情報が含まれる`() = runTest {
+        val userId = UUID.randomUUID()
+        val memoId = UUID.randomUUID()
+        val folderId = UUID.randomUUID()
+        val folder = Folder.create(
+            id = folderId,
+            userId = userId,
+            name = "仕事",
+        )
+
+        // フォルダーに紐づくメモを作成
+        val memo = VoiceMemo.create(id = memoId, userId = userId)
+            .completeFormatting(
+                title = "テストメモ",
+                content = "コンテンツ",
+                tags = emptyList(),
+                folderId = folderId,
+            )
+
+        val voiceMemoRepository = InMemoryVoiceMemoRepository(
+            initialMemos = listOf(memo),
+        )
+        val folderRepository = InMemoryFolderRepository(
+            initialFolders = listOf(folder),
+        )
+        val useCase = GetMemoUseCase(voiceMemoRepository, folderRepository)
+
+        val result = useCase.execute(GetMemoInput(memoId = memoId, userId = userId))
+
+        // メモ情報を確認
+        assertEquals(memoId, result.memo.id)
+        assertEquals(userId, result.memo.userId)
+
+        // フォルダー情報を確認
+        assertNotNull(result.folder)
+        assertEquals(folderId, result.folder?.id)
+        assertEquals("仕事", result.folder?.name)
+        assertEquals("仕事", result.folderPath)
+    }
+
+    @Test
+    fun `階層フォルダーに紐づくメモを取得するとフルパスが含まれる`() = runTest {
+        val userId = UUID.randomUUID()
+        val memoId = UUID.randomUUID()
+        val parentFolderId = UUID.randomUUID()
+        val childFolderId = UUID.randomUUID()
+
+        val parentFolder = Folder.create(
+            id = parentFolderId,
+            userId = userId,
+            name = "仕事",
+        )
+        val childFolder = Folder.create(
+            id = childFolderId,
+            userId = userId,
+            name = "プロジェクトA",
+            parentId = parentFolderId,
+        )
+
+        // 子フォルダーに紐づくメモを作成
+        val memo = VoiceMemo.create(id = memoId, userId = userId)
+            .completeFormatting(
+                title = "テストメモ",
+                content = "コンテンツ",
+                tags = emptyList(),
+                folderId = childFolderId,
+            )
+
+        val voiceMemoRepository = InMemoryVoiceMemoRepository(
+            initialMemos = listOf(memo),
+        )
+        val folderRepository = InMemoryFolderRepository(
+            initialFolders = listOf(parentFolder, childFolder),
+        )
+        val useCase = GetMemoUseCase(voiceMemoRepository, folderRepository)
+
+        val result = useCase.execute(GetMemoInput(memoId = memoId, userId = userId))
+
+        // メモ情報を確認
+        assertEquals(memoId, result.memo.id)
+
+        // フォルダー情報を確認
+        assertNotNull(result.folder)
+        assertEquals(childFolderId, result.folder?.id)
+        assertEquals("プロジェクトA", result.folder?.name)
+        assertEquals("仕事/プロジェクトA", result.folderPath)
+    }
+
+    // インメモリで動作する FolderRepository のテストダブル
+    private class InMemoryFolderRepository(
+        initialFolders: List<Folder> = emptyList(),
+    ) : FolderRepository {
+        private val folders = initialFolders.toMutableList()
+
+        override suspend fun save(folder: Folder): Folder {
+            folders.removeIf { it.id == folder.id }
+            folders += folder
+            return folder
+        }
+
+        override suspend fun findById(id: UUID): Folder? = folders.find { it.id == id }
+
+        override suspend fun findByUserId(userId: UUID): List<Folder> = folders.filter { it.userId == userId }
+
+        override suspend fun findByUserIdAndParentId(userId: UUID, parentId: UUID?): List<Folder> =
+            folders.filter { it.userId == userId && it.parentId == parentId }
+
+        override suspend fun findByUserIdAndPath(userId: UUID, path: String): Folder? = null
+
+        override suspend fun findDescendantIds(folderId: UUID): List<UUID> = emptyList()
+
+        override suspend fun delete(id: UUID) {
+            folders.removeIf { it.id == id }
+        }
+
+        override suspend fun existsByUserIdAndParentIdAndName(
+            userId: UUID,
+            parentId: UUID?,
+            name: String,
+            excludeId: UUID?,
+        ): Boolean =
+            folders.any {
+                it.userId == userId &&
+                        it.parentId == parentId &&
+                        it.name == name &&
+                        (excludeId == null || it.id != excludeId)
+            }
+
+        override fun deleteByUserId(userId: UUID) {
+            folders.removeIf { it.userId == userId }
+        }
     }
 }


### PR DESCRIPTION
- MemoDetailResponseにfolderフィールドを追加
- GetMemoUseCaseでフォルダー情報とパスを取得するロジックを追加
- GetMemoOutputにfolderとfolderPathを追加
- フォルダー情報を含むテストケースを追加（単一フォルダー、階層フォルダー）
- MemoControllerTestのGetMemoOutput生成箇所を修正

## 関連Issue
<!-- #の後ろに対応するissue番号を書く -->
Closes #92 

## やったこと

## 動作確認
<!-- テスト内容など -->
- [x] ビルドできた
- [x] test完了した
- [x] swaggerにてメモ詳細にpathが追加されていることを確認動作確認完了

## 参考にした資料

