### PR TITLE
リアルタイム文字起こし中間結果を返さないように変更 #113

### DIFF
--- a/src/main/kotlin/com/assari/voicebooklm/infrastructure/websocket/TranscriptionWebSocketHandler.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/infrastructure/websocket/TranscriptionWebSocketHandler.kt
@@ -217,7 +217,7 @@ class TranscriptionWebSocketHandler(
         val config = StreamingTranscriptionConfig(
             languageCode = languageCode,
             sampleRateHertz = 16000,
-            enableInterimResults = true,
+            enableInterimResults = false,
         )
 
         val transcriptionSession = sessionManager.createSession(userId, session.id, config)


### PR DESCRIPTION
フロント側で中間結果の文字起こしを表示せずに確定結果のみを表示するようなUIUXに変更することになったので変更

## 関連Issue
<!-- #の後ろに対応するissue番号を書く -->
Closes #113 

## やったこと

## 動作確認
<!-- テスト内容など -->
- [ ] ビルドできた

## 参考にした資料

