### PR TITLE
録音時にフォルダ・タグを指定できるようにする #115

### DIFF
--- a/src/main/kotlin/com/assari/voicebooklm/domain/gateway/MemoFormatter.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/domain/gateway/MemoFormatter.kt
@@ -17,6 +17,10 @@ data class MemoFormatCommand(
     val transcript: String,
     /** 既存フォルダーのパス一覧（AIが参考にする） */
     val existingFolderPaths: List<String> = emptyList(),
+    /** ユーザーがフォルダを指定済みか（folderId または folderPath）。true のときAIにフォルダ一覧を渡さない */
+    val folderSpecifiedByUser: Boolean = false,
+    /** ユーザーが指定したタグ。プロンプトに「必ず含める」として渡す */
+    val userSpecifiedTags: List<String> = emptyList(),
 )
 
 /**

--- a/src/main/kotlin/com/assari/voicebooklm/infrastructure/api/ai/GeminiAiMemoFormatter.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/infrastructure/api/ai/GeminiAiMemoFormatter.kt
@@ -43,7 +43,12 @@ class GeminiAiMemoFormatter(
         .build()
 
     override suspend fun format(command: MemoFormatCommand): MemoFormatResult {
-        val request = GeminiRequest.fromTranscript(command.transcript, command.existingFolderPaths)
+        val request = GeminiRequest.fromTranscript(
+            transcript = command.transcript,
+            existingFolderPaths = command.existingFolderPaths,
+            folderSpecifiedByUser = command.folderSpecifiedByUser,
+            userSpecifiedTags = command.userSpecifiedTags,
+        )
 
         return runCatching {
             client.post()
@@ -94,21 +99,40 @@ data class GeminiRequest(
         fun fromTranscript(
             transcript: String,
             existingFolderPaths: List<String> = emptyList(),
+            folderSpecifiedByUser: Boolean = false,
+            userSpecifiedTags: List<String> = emptyList(),
         ): GeminiRequest {
-            val folderSection = if (existingFolderPaths.isNotEmpty()) {
-                val folderList = existingFolderPaths.joinToString("\n") { "- $it" }
-                """
-                【既存フォルダー】
-                $folderList
+            val folderSection = when {
+                folderSpecifiedByUser -> """
+                    保存先フォルダーはユーザーが指定済みです。
+                    フォルダー行には「未分類」と出力してください。
+                """.trimIndent()
+                existingFolderPaths.isNotEmpty() -> {
+                    val folderList = existingFolderPaths.joinToString("\n") { "- $it" }
+                    """
+                    【既存フォルダー】
+                    $folderList
 
-                上記から内容に最も合うフォルダーを1つ選択してください。
-                適切なものがなければ新規作成してください（最大3階層）。
+                    上記から内容に最も合うフォルダーを1つ選択してください。
+                    適切なものがなければ新規作成してください（最大3階層）。
+                    """.trimIndent()
+                }
+                else -> """
+                    フォルダー名を1〜3階層で作成してください（例: "仕事/会議"）。
+                    分類が難しい場合は「未分類」にしてください。
+                """.trimIndent()
+            }
+
+            val tagSection = if (userSpecifiedTags.isNotEmpty()) {
+                val tagList = userSpecifiedTags.joinToString(", ")
+                """
+                【ユーザー指定タグ】
+                以下のタグはユーザーが事前に指定したものです。タグ行にはこれらを必ず含めてください。
+                - $tagList
+                上記に加えて、内容に合うタグを必要な分だけ追加し、タグ行は全体で2〜4個（カンマ区切り）にしてください。
                 """.trimIndent()
             } else {
-                """
-                フォルダー名を1〜3階層で作成してください（例: "仕事/会議"）。
-                分類が難しい場合は「未分類」にしてください。
-                """.trimIndent()
+                ""
             }
 
             val prompt = """
@@ -134,6 +158,8 @@ data class GeminiRequest(
                 - 判断が難しい場合は「未分類」
 
                 $folderSection
+
+                $tagSection
 
                 【基本方針】
                 - 箇条書きよりも文章を優先する

--- a/src/main/kotlin/com/assari/voicebooklm/infrastructure/api/ai/GeminiAiMemoFormatter.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/infrastructure/api/ai/GeminiAiMemoFormatter.kt
@@ -129,11 +129,12 @@ data class GeminiRequest(
                 【ユーザー指定タグ】
                 以下のタグはユーザーが事前に指定したものです。タグ行にはこれらを必ず含めてください。
                 - $tagList
-                上記に加えて、内容に合うタグを必要な分だけ追加し、タグ行は全体で2〜4個（カンマ区切り）にしてください。
+                上記に加えて、内容に合うタグを必要な分だけ追加し、ユーザー指定タグを含めてタグ行は全体で2〜4個（カンマ区切り）になることを目安にしてください。
                 """.trimIndent()
             } else {
                 ""
             }
+            val tagBlock = if (tagSection.isNotEmpty()) "\n\n$tagSection\n\n" else ""
 
             val prompt = """
                 あなたは音声メモの文字起こしを「読みやすい文章」に整えるアシスタントです。
@@ -158,9 +159,7 @@ data class GeminiRequest(
                 - 判断が難しい場合は「未分類」
 
                 $folderSection
-
-                $tagSection
-
+                $tagBlock
                 【基本方針】
                 - 箇条書きよりも文章を優先する
                 - 会話調・口語表現は自然な書き言葉に直す

--- a/src/main/kotlin/com/assari/voicebooklm/presentation/controller/memo/MemoController.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/presentation/controller/memo/MemoController.kt
@@ -411,13 +411,16 @@ class MemoController(
             throw ResponseStatusException(HttpStatus.UNAUTHORIZED, "認証が必要です")
         }
 
-        // ユースケース実行
+        // ユースケース実行（DomainException は GlobalExceptionHandler が 404 等に変換する）
         val result = try {
             formatMemoUseCase.execute(
                 FormatMemoInput(
                     userId = userId,
                     transcription = request.transcription,
                     language = request.language,
+                    folderId = request.folderId,
+                    folderPath = request.folderPath,
+                    tags = request.tags,
                 )
             )
         } catch (ex: IllegalArgumentException) {

--- a/src/main/kotlin/com/assari/voicebooklm/presentation/controller/memo/MemoRequest.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/presentation/controller/memo/MemoRequest.kt
@@ -2,6 +2,7 @@ package com.assari.voicebooklm.presentation.controller.memo
 
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
+import java.util.UUID
 
 /**
  * メモ更新リクエスト
@@ -37,4 +38,24 @@ data class FormatMemoRequest(
 
     /** 言語コード（例: ja-JP）。指定がない場合は ja-JP がデフォルト */
     val language: String? = null,
+
+    /**
+     * 保存先フォルダーID。
+     * 指定時はAIのフォルダ分類は行わずこのフォルダに保存する。
+     * folderPath と両方指定された場合は folderId を優先する。
+     */
+    val folderId: UUID? = null,
+
+    /**
+     * 保存先のフォルダーパス（例: "仕事/プロジェクトA"、"趣味"）。
+     * 指定時はこのパスに保存し、必要なフォルダは最大3階層まで自動作成する。
+     * folderId が指定されている場合は無視される。
+     */
+    val folderPath: String? = null,
+
+    /**
+     * 録音時に付けておきたいタグ。
+     * AI提案タグとマージして保存する。null のときはAI提案のみ。
+     */
+    val tags: List<String>? = null,
 )

--- a/src/main/kotlin/com/assari/voicebooklm/usecase/memo/FormatMemoUseCase.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/usecase/memo/FormatMemoUseCase.kt
@@ -68,10 +68,11 @@ open class FormatMemoUseCase(
 
         // 2. 既存フォルダーパスを取得（AI整形用）
         val existingFolderPaths = getExistingFolderPaths(input.userId)
+        val trimmedFolderPath = input.folderPath?.trim()
 
         // 3. AI整形処理（失敗した場合はフォールバックで続行）
-        val folderSpecifiedByUser = input.folderId != null || !input.folderPath.isNullOrBlank()
-        val userSpecifiedTags = input.tags.orEmpty()
+        val folderSpecifiedByUser = input.folderId != null || trimmedFolderPath?.isNotBlank() == true
+        val userSpecifiedTags = input.tags?.map { it.trim() }?.filter { it.isNotEmpty() }.orEmpty()
         voiceMemo = voiceMemo.startFormatting()
         val formatResult = executionTimer.measure {
             runCatching {
@@ -95,20 +96,21 @@ open class FormatMemoUseCase(
         // 4. フォルダIDの決定（ユーザー指定優先、なければAIの結果を解決）
         val effectiveFolderId = when {
             input.folderId != null -> input.folderId
-            input.folderPath?.trim()?.isNotBlank() == true ->
-                resolveFolderId(input.userId, input.folderPath!!.trim())
+            trimmedFolderPath?.isNotBlank() == true ->
+                resolveFolderId(input.userId, trimmedFolderPath)
             else -> resolveFolderId(input.userId, memoFormat.folderPath)
         }
 
         // 5. タグのマージ（ユーザー指定 + AI提案、重複は小文字で除去）
-        val userTags = input.tags?.map { it.trim() }?.filter { it.isNotEmpty() }.orEmpty()
-        val mergedTags = (userTags + memoFormat.tags).distinctBy { it.lowercase() }
+        // 大文字小文字のみ異なるタグがある場合は最初に出現したものを保持するため、
+        // ユーザー指定タグを先に結合している（ユーザー指定タグの表記を優先する）
+        val effectiveTags = (userSpecifiedTags + memoFormat.tags).distinctBy { it.lowercase() }
 
         val formattingFallbackUsed = memoFormat.title == "ボイスメモ" && memoFormat.tags.isEmpty()
         voiceMemo = voiceMemo.completeFormatting(
             title = memoFormat.title,
             content = memoFormat.content,
-            tags = mergedTags,
+            tags = effectiveTags,
             fallbackUsed = formattingFallbackUsed,
             folderId = effectiveFolderId,
         )
@@ -181,7 +183,14 @@ data class FormatMemoInput(
     val language: String? = null,
     /** 保存先フォルダーID。指定時はAIのフォルダ分類は行わない。folderPath より優先される */
     val folderId: UUID? = null,
-    /** 保存先のフォルダーパス。指定時は resolveOrCreate で解決（必要なフォルダは自動作成）。folderId が指定されている場合は無視 */
+    /**
+     * 保存先のフォルダーパス。
+     * 指定時は [FolderPathResolver.resolveOrCreate] で解決し、
+     * 指定されたパスのフォルダが存在しない場合は最大3階層まで自動作成する。
+     * 4階層以上のパスを指定した場合もバリデーションエラーにはならず、
+     * 3階層目までのフォルダが作成され、そのリーフが保存先となる。
+     * [folderId] が指定されている場合は無視される。
+     */
     val folderPath: String? = null,
     /** 録音時に付けたいタグ。AI提案タグとマージして保存する */
     val tags: List<String>? = null,

--- a/src/main/kotlin/com/assari/voicebooklm/usecase/memo/FormatMemoUseCase.kt
+++ b/src/main/kotlin/com/assari/voicebooklm/usecase/memo/FormatMemoUseCase.kt
@@ -1,5 +1,7 @@
 package com.assari.voicebooklm.usecase.memo
 
+import com.assari.voicebooklm.domain.exception.DomainException
+import com.assari.voicebooklm.domain.exception.ErrorCode
 import com.assari.voicebooklm.domain.gateway.MemoFormatCommand
 import com.assari.voicebooklm.domain.gateway.MemoFormatResult
 import com.assari.voicebooklm.domain.gateway.MemoFormatter
@@ -40,6 +42,15 @@ open class FormatMemoUseCase(
     open suspend fun execute(input: FormatMemoInput): FormatMemoOutput {
         require(input.transcription.isNotBlank()) { "Transcription text must not be empty" }
 
+        // folderId 指定時は AI 呼び出し前にフォルダの存在・所有を検証する
+        input.folderId?.let { folderId ->
+            val folder = folderRepository.findById(folderId)
+                ?: throw DomainException(ErrorCode.FOLDER_NOT_FOUND, "フォルダーが見つかりません: $folderId")
+            if (folder.userId != input.userId) {
+                throw DomainException(ErrorCode.FOLDER_NOT_FOUND, "フォルダーが見つかりません: $folderId")
+            }
+        }
+
         val overallMark = timeSource.markNow()
         val languageCode = input.language ?: "ja-JP"
 
@@ -59,6 +70,8 @@ open class FormatMemoUseCase(
         val existingFolderPaths = getExistingFolderPaths(input.userId)
 
         // 3. AI整形処理（失敗した場合はフォールバックで続行）
+        val folderSpecifiedByUser = input.folderId != null || !input.folderPath.isNullOrBlank()
+        val userSpecifiedTags = input.tags.orEmpty()
         voiceMemo = voiceMemo.startFormatting()
         val formatResult = executionTimer.measure {
             runCatching {
@@ -67,6 +80,8 @@ open class FormatMemoUseCase(
                         userId = input.userId,
                         transcript = input.transcription,
                         existingFolderPaths = existingFolderPaths,
+                        folderSpecifiedByUser = folderSpecifiedByUser,
+                        userSpecifiedTags = userSpecifiedTags,
                     ),
                 )
             }.onFailure { ex ->
@@ -77,19 +92,28 @@ open class FormatMemoUseCase(
         }
         val memoFormat = formatResult.value
 
-        // 4. フォルダーパスをIDに解決（必要に応じて作成）
-        val folderId = resolveFolderId(input.userId, memoFormat.folderPath)
+        // 4. フォルダIDの決定（ユーザー指定優先、なければAIの結果を解決）
+        val effectiveFolderId = when {
+            input.folderId != null -> input.folderId
+            input.folderPath?.trim()?.isNotBlank() == true ->
+                resolveFolderId(input.userId, input.folderPath!!.trim())
+            else -> resolveFolderId(input.userId, memoFormat.folderPath)
+        }
+
+        // 5. タグのマージ（ユーザー指定 + AI提案、重複は小文字で除去）
+        val userTags = input.tags?.map { it.trim() }?.filter { it.isNotEmpty() }.orEmpty()
+        val mergedTags = (userTags + memoFormat.tags).distinctBy { it.lowercase() }
 
         val formattingFallbackUsed = memoFormat.title == "ボイスメモ" && memoFormat.tags.isEmpty()
         voiceMemo = voiceMemo.completeFormatting(
             title = memoFormat.title,
             content = memoFormat.content,
-            tags = memoFormat.tags,
+            tags = mergedTags,
             fallbackUsed = formattingFallbackUsed,
-            folderId = folderId,
+            folderId = effectiveFolderId,
         )
 
-        // 5. 永続化
+        // 6. 永続化
         val (savedVoiceMemo, persistenceDuration) = executionTimer.measure {
             voiceMemoRepository.save(voiceMemo)
         }
@@ -155,6 +179,12 @@ data class FormatMemoInput(
     val transcription: String,
     /** 言語コード（例: ja-JP） */
     val language: String? = null,
+    /** 保存先フォルダーID。指定時はAIのフォルダ分類は行わない。folderPath より優先される */
+    val folderId: UUID? = null,
+    /** 保存先のフォルダーパス。指定時は resolveOrCreate で解決（必要なフォルダは自動作成）。folderId が指定されている場合は無視 */
+    val folderPath: String? = null,
+    /** 録音時に付けたいタグ。AI提案タグとマージして保存する */
+    val tags: List<String>? = null,
 )
 
 /**

--- a/src/test/kotlin/com/assari/voicebooklm/presentation/controller/memo/MemoControllerTest.kt
+++ b/src/test/kotlin/com/assari/voicebooklm/presentation/controller/memo/MemoControllerTest.kt
@@ -729,4 +729,83 @@ class MemoControllerTest {
         val body = requireNotNull(response.body) { "response body should not be null" }
         assertEquals(memoId, body.memoId)
     }
+
+    @Test
+    fun `formatMemo に folderId, folderPath, tags を指定した場合に use case に正しく渡り 201 が返る`() = runBlocking {
+        val userId = UUID.randomUUID()
+        val memoId = UUID.randomUUID()
+        val folderId = UUID.randomUUID()
+        val folderPath = "仕事/テスト"
+        val tags = listOf("ユーザータグ1", "ユーザータグ2")
+        val transcriptionText = "文字起こしテキスト"
+
+        val memo = VoiceMemo.create(id = memoId, userId = userId)
+            .startTranscription()
+            .completeTranscription(transcriptionText)
+            .startFormatting()
+            .completeFormatting(
+                title = "タイトル",
+                content = "本文",
+                tags = listOf("ユーザータグ1", "ユーザータグ2", "AIタグ"),
+            )
+
+        coEvery {
+            formatMemoUseCase.execute(
+                match {
+                    it.userId == userId &&
+                        it.transcription == transcriptionText &&
+                        it.language == "ja-JP" &&
+                        it.folderId == folderId &&
+                        it.folderPath == folderPath &&
+                        it.tags == tags
+                },
+            )
+        } returns FormatMemoOutput(
+            voiceMemo = memo,
+            processingTime = FormatProcessingTime(
+                formatting = 100.milliseconds,
+                persistence = 30.milliseconds,
+                total = 130.milliseconds,
+            ),
+        )
+
+        val request = FormatMemoRequest(
+            transcription = transcriptionText,
+            language = "ja-JP",
+            folderId = folderId,
+            folderPath = folderPath,
+            tags = tags,
+        )
+
+        val response = controller.formatMemo(userId, request)
+
+        assertEquals(HttpStatus.CREATED, response.statusCode)
+        val body = requireNotNull(response.body) { "response body should not be null" }
+        assertEquals(memoId, body.memoId)
+        assertEquals("タイトル", body.title)
+        assertEquals(listOf("ユーザータグ1", "ユーザータグ2", "AIタグ"), body.tags)
+    }
+
+    @Test
+    fun `formatMemo で folderId 指定時に FOLDER_NOT_FOUND の場合は DomainException がスローされる`() = runBlocking {
+        val userId = UUID.randomUUID()
+        val folderId = UUID.randomUUID()
+        val request = FormatMemoRequest(
+            transcription = "テスト",
+            language = null,
+            folderId = folderId,
+            folderPath = null,
+            tags = null,
+        )
+
+        coEvery {
+            formatMemoUseCase.execute(any())
+        } throws DomainException(ErrorCode.FOLDER_NOT_FOUND, "フォルダーが見つかりません: $folderId")
+
+        val exception = assertThrows<DomainException> {
+            controller.formatMemo(userId, request)
+        }
+
+        assertEquals(ErrorCode.FOLDER_NOT_FOUND, exception.code)
+    }
 }

--- a/src/test/kotlin/com/assari/voicebooklm/usecase/memo/FormatMemoUseCaseTest.kt
+++ b/src/test/kotlin/com/assari/voicebooklm/usecase/memo/FormatMemoUseCaseTest.kt
@@ -1,5 +1,8 @@
 package com.assari.voicebooklm.usecase.memo
 
+import com.assari.voicebooklm.domain.exception.ErrorCode
+import com.assari.voicebooklm.domain.exception.DomainException
+import com.assari.voicebooklm.domain.model.Folder
 import com.assari.voicebooklm.domain.model.FormattingStatus
 import com.assari.voicebooklm.domain.model.TranscriptionStatus
 import com.assari.voicebooklm.infrastructure.service.FolderPathResolver
@@ -251,5 +254,254 @@ class FormatMemoUseCaseTest {
         // メモにフォルダーIDが設定されていることを検証
         assertNotNull(result.voiceMemo.formatting.folderId)
         assertEquals(childFolder?.id, result.voiceMemo.formatting.folderId)
+    }
+
+    @Test
+    fun `folderId 指定時にフォルダが存在しない場合は DomainException を投げる`() = runTest {
+        val userId = UUID.randomUUID()
+        val nonExistentFolderId = UUID.randomUUID()
+        val folderRepository = FakeFolderRepository(emptyList())
+        val useCase = FormatMemoUseCase(
+            voiceMemoRepository = InMemoryVoiceMemoRepository(),
+            memoFormatter = FakeMemoFormatter("", "", emptyList()),
+            folderRepository = folderRepository,
+            folderPathResolver = FolderPathResolver(folderRepository),
+            executionTimer = FakeExecutionTimer(TestTimeSource(), emptyList()),
+            timeSource = TestTimeSource(),
+        )
+
+        val ex = assertThrowsSuspend<DomainException> {
+            useCase.execute(
+                FormatMemoInput(
+                    userId = userId,
+                    transcription = "テスト",
+                    folderId = nonExistentFolderId,
+                ),
+            )
+        }
+        assertEquals(ErrorCode.FOLDER_NOT_FOUND, ex.code)
+    }
+
+    @Test
+    fun `folderId 指定時に他人のフォルダを指定した場合は DomainException を投げる`() = runTest {
+        val userId = UUID.randomUUID()
+        val otherUserId = UUID.randomUUID()
+        val otherUserFolder = Folder.create(
+            id = UUID.randomUUID(),
+            userId = otherUserId,
+            name = "他人のフォルダ",
+            parentId = null,
+        )
+        val folderRepository = FakeFolderRepository(listOf(otherUserFolder))
+        folderRepository.save(otherUserFolder)
+        val useCase = FormatMemoUseCase(
+            voiceMemoRepository = InMemoryVoiceMemoRepository(),
+            memoFormatter = FakeMemoFormatter("", "", emptyList()),
+            folderRepository = folderRepository,
+            folderPathResolver = FolderPathResolver(folderRepository),
+            executionTimer = FakeExecutionTimer(TestTimeSource(), emptyList()),
+            timeSource = TestTimeSource(),
+        )
+
+        val ex = assertThrowsSuspend<DomainException> {
+            useCase.execute(
+                FormatMemoInput(
+                    userId = userId,
+                    transcription = "テスト",
+                    folderId = otherUserFolder.id,
+                ),
+            )
+        }
+        assertEquals(ErrorCode.FOLDER_NOT_FOUND, ex.code)
+    }
+
+    @Test
+    fun `folderId と folderPath を両方指定した場合は folderId が優先される`() = runTest {
+        val userId = UUID.randomUUID()
+        val timeSource = TestTimeSource()
+        val userFolder = Folder.create(
+            id = UUID.randomUUID(),
+            userId = userId,
+            name = "指定フォルダ",
+            parentId = null,
+        )
+        val folderRepository = FakeFolderRepository(listOf(userFolder))
+        folderRepository.save(userFolder)
+        val memoFormatter = FakeMemoFormatter(
+            title = "タイトル",
+            content = "本文",
+            tags = emptyList(),
+            folderPath = "AIが提案したパス/サブ",
+        )
+        val useCase = FormatMemoUseCase(
+            voiceMemoRepository = InMemoryVoiceMemoRepository(),
+            memoFormatter = memoFormatter,
+            folderRepository = folderRepository,
+            folderPathResolver = FolderPathResolver(folderRepository),
+            executionTimer = FakeExecutionTimer(
+                timeSource = timeSource,
+                durations = listOf(100.milliseconds, 30.milliseconds),
+            ),
+            timeSource = timeSource,
+        )
+
+        val result = useCase.execute(
+            FormatMemoInput(
+                userId = userId,
+                transcription = "テスト",
+                folderId = userFolder.id,
+                folderPath = "無視されるパス/パス",
+            ),
+        )
+
+        assertEquals(userFolder.id, result.voiceMemo.formatting.folderId)
+        // folderPath で解決したフォルダは作成されない（folderId 優先のため）
+        val pathFolderCount = folderRepository.savedFolders.count { it.name == "無視されるパス" || it.name == "パス" }
+        assertEquals(0, pathFolderCount)
+    }
+
+    @Test
+    fun `folderPath 指定時は resolveOrCreate でフォルダが解決または作成される`() = runTest {
+        val userId = UUID.randomUUID()
+        val timeSource = TestTimeSource()
+        val memoFormatter = FakeMemoFormatter(
+            title = "タイトル",
+            content = "本文",
+            tags = emptyList(),
+            folderPath = "仕事/プロジェクトA",
+        )
+        val voiceMemoRepository = InMemoryVoiceMemoRepository()
+        val folderRepository = FakeFolderRepository()
+        val folderPathResolver = FolderPathResolver(folderRepository)
+        val useCase = FormatMemoUseCase(
+            voiceMemoRepository = voiceMemoRepository,
+            memoFormatter = memoFormatter,
+            folderRepository = folderRepository,
+            folderPathResolver = folderPathResolver,
+            executionTimer = FakeExecutionTimer(
+                timeSource = timeSource,
+                durations = listOf(100.milliseconds, 30.milliseconds),
+            ),
+            timeSource = timeSource,
+        )
+
+        val result = useCase.execute(
+            FormatMemoInput(
+                userId = userId,
+                transcription = "テスト",
+                folderPath = "私用/テスト用",
+            ),
+        )
+
+        // input.folderPath で指定したパスが解決・作成されていること
+        assertEquals(2, folderRepository.savedFolders.size)
+        val privateFolder = folderRepository.savedFolders.find { it.name == "私用" }
+        val testFolder = folderRepository.savedFolders.find { it.name == "テスト用" }
+        assertNotNull(privateFolder)
+        assertNotNull(testFolder)
+        assertEquals(testFolder?.id, result.voiceMemo.formatting.folderId)
+    }
+
+    @Test
+    fun `tags 指定時はユーザー指定タグと AI 提案タグがマージされユーザー指定が先になる`() = runTest {
+        val userId = UUID.randomUUID()
+        val timeSource = TestTimeSource()
+        val memoFormatter = FakeMemoFormatter(
+            title = "タイトル",
+            content = "本文",
+            tags = listOf("会議", "議事録"),
+        )
+        val useCase = FormatMemoUseCase(
+            voiceMemoRepository = InMemoryVoiceMemoRepository(),
+            memoFormatter = memoFormatter,
+            folderRepository = FakeFolderRepository(),
+            folderPathResolver = FolderPathResolver(FakeFolderRepository()),
+            executionTimer = FakeExecutionTimer(
+                timeSource = timeSource,
+                durations = listOf(100.milliseconds, 30.milliseconds),
+            ),
+            timeSource = timeSource,
+        )
+
+        val result = useCase.execute(
+            FormatMemoInput(
+                userId = userId,
+                transcription = "テスト",
+                tags = listOf("ユーザータグ", "録音"),
+            ),
+        )
+
+        assertEquals(
+            listOf("ユーザータグ", "録音", "会議", "議事録"),
+            result.voiceMemo.tags,
+        )
+    }
+
+    @Test
+    fun `tags で大文字小文字のみ異なる場合はユーザー指定タグの表記が優先される`() = runTest {
+        val userId = UUID.randomUUID()
+        val timeSource = TestTimeSource()
+        val memoFormatter = FakeMemoFormatter(
+            title = "タイトル",
+            content = "本文",
+            tags = listOf("Meeting", "議事録"),
+        )
+        val useCase = FormatMemoUseCase(
+            voiceMemoRepository = InMemoryVoiceMemoRepository(),
+            memoFormatter = memoFormatter,
+            folderRepository = FakeFolderRepository(),
+            folderPathResolver = FolderPathResolver(FakeFolderRepository()),
+            executionTimer = FakeExecutionTimer(
+                timeSource = timeSource,
+                durations = listOf(100.milliseconds, 30.milliseconds),
+            ),
+            timeSource = timeSource,
+        )
+
+        val result = useCase.execute(
+            FormatMemoInput(
+                userId = userId,
+                transcription = "テスト",
+                tags = listOf("meeting"),
+            ),
+        )
+
+        // distinctBy { it.lowercase() } で最初の出現が残るため "meeting" が保持される
+        assertTrue(result.voiceMemo.tags.any { it == "meeting" })
+        assertFalse(result.voiceMemo.tags.any { it == "Meeting" })
+    }
+
+    @Test
+    fun `tags に空文字列や空白のみの要素が含まれる場合は除去されてからマージされる`() = runTest {
+        val userId = UUID.randomUUID()
+        val timeSource = TestTimeSource()
+        val memoFormatter = FakeMemoFormatter(
+            title = "タイトル",
+            content = "本文",
+            tags = listOf("AIタグ"),
+        )
+        val useCase = FormatMemoUseCase(
+            voiceMemoRepository = InMemoryVoiceMemoRepository(),
+            memoFormatter = memoFormatter,
+            folderRepository = FakeFolderRepository(),
+            folderPathResolver = FolderPathResolver(FakeFolderRepository()),
+            executionTimer = FakeExecutionTimer(
+                timeSource = timeSource,
+                durations = listOf(100.milliseconds, 30.milliseconds),
+            ),
+            timeSource = timeSource,
+        )
+
+        val result = useCase.execute(
+            FormatMemoInput(
+                userId = userId,
+                transcription = "テスト",
+                tags = listOf("  有効  ", "", "   ", "タグ"),
+            ),
+        )
+
+        assertEquals(listOf("有効", "タグ", "AIタグ"), result.voiceMemo.tags)
+        assertEquals("有効", result.voiceMemo.tags[0])
+        assertEquals("タグ", result.voiceMemo.tags[1])
     }
 }


### PR DESCRIPTION
## 概要
録音時に、保存先フォルダとタグを事前指定できるようにした。

## 関連Issue
<!-- #の後ろに対応するissue番号を書く -->
Closes #115

## やったこと

### フォルダ指定
- **folderId** (UUID?, 任意): 既存フォルダをIDで指定。存在・所有者チェック後にそのフォルダに保存する。
- **folderPath** (String?, 任意): パスで指定（例: `"趣味"`, `"仕事/プロジェクトA"`）
- 両方指定時は **folderId** を優先。どちらも指定なしのときは従来どおり AI にフォルダ分類させる。
### タグ指定
- **tags** (List<String>?, 任意): 録音時に付けたいタグ。AI 提案タグとマージして保存する（ユーザー→AI の順、大文字小文字で重複除去）。

### プロンプト
- フォルダをユーザー指定しているときは、AI にはフォルダ一覧を渡さず「保存先はユーザー指定済み。フォルダー行は未分類で出力」とだけ伝える。
- ユーザー指定タグがあるときだけ、プロンプトに「【ユーザー指定タグ】… 必ず含める」を追加する。

### 変更ファイル
MemoRequest.kt, MemoController.kt, FormatMemoUseCase.kt, MemoFormatter.kt, GeminiAiMemoFormatter.kt

## 動作確認
<!-- テスト内容など -->
- [x] ビルドできた
- [x] `./gradlew test` が通った（FormatMemoUseCaseTest, MemoControllerTest 含む）

## 参考にした資料